### PR TITLE
docs: expand product vision and contribution north star

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,21 +1,81 @@
-# Product
-
-## Purpose
-
-This document defines the long-term direction of openai-sdk-helpers.
+# Product Vision
 
 ## Mission
 
-Keep openai-sdk-helpers simple, reliable, typed, documented, and maintainable.
+Build a production-ready Python toolkit that makes applications using the official OpenAI Python SDK and Agents SDK simpler, consistent, and type-safe.
 
-## Principles
+The package provides reusable primitives, not applications.
 
-- Developer experience first.
-- Explicit over magic.
-- Simple over clever.
-- Reliability over features.
-- Documentation, tests, and types are part of every feature.
+## Product promise
 
-## Guiding Question
+Users should write less repeated SDK plumbing without losing access to official OpenAI concepts or clients. Public behavior must be typed, predictable, documented, testable, and backward compatible.
 
-> Does this make the product better for its users?
+## Target users
+
+- Python developers integrating OpenAI APIs
+- Library authors building reusable AI components
+- Teams operating typed OpenAI workflows in production
+
+## Non-goals
+
+This project is not an end-user application, hosted platform, universal agent framework, replacement SDK, or home for customer-specific business logic.
+
+## Product principles
+
+1. **SDK-first** — follow official terminology and capabilities.
+2. **Thin abstractions** — remove more complexity than they introduce.
+3. **Explicit behavior** — avoid hidden state, surprising mutation, and magic.
+4. **Strong typing** — keep public APIs useful to static analysis.
+5. **Composable modules** — allow users to adopt only what they need.
+6. **Production readiness** — include validation, errors, logging, lifecycle handling, documentation, and tests as appropriate.
+7. **Clear escape hatches** — preserve access to underlying SDK clients and arguments.
+8. **Backward compatibility** — evolve public APIs deliberately under semantic versioning.
+9. **Focused scope** — accept only broadly reusable OpenAI integration helpers.
+
+## What belongs
+
+- Typed wrappers around official SDK workflows
+- Responses API and Agents SDK helpers
+- Prompt rendering and structured-output utilities
+- Tool execution and orchestration primitives
+- Vector-store and file-processing helpers
+- Retry, logging, lifecycle, and persistence utilities
+- Supported examples and documentation
+
+## API philosophy
+
+Public APIs should be small, typed, unsurprising, and stable. Internal helpers remain private until downstream users need a supported contract.
+
+A public API should use official OpenAI terminology, expose meaningful defaults without hiding important behavior, support dependency injection, return structured values when practical, raise actionable exceptions, and preserve access to underlying SDK objects.
+
+## Feature acceptance test
+
+Before adding a feature, confirm that it:
+
+1. Solves a repeated OpenAI SDK integration problem.
+2. Is broadly reusable across projects.
+3. Is thinner than the workflow it simplifies.
+4. Has clear types and documentation.
+5. Preserves access to the underlying SDK capability.
+6. Composes without mandatory framework coupling.
+7. Can be maintained without weakening compatibility.
+
+## Quality bar
+
+Public features should include complete type hints, tests for behavior and failures, user documentation, concise examples, NumPy-style docstrings, compatibility notes, and release notes when applicable.
+
+Changes must pass formatting, documentation style, static typing, tests, and package validation before release.
+
+## Decision hierarchy
+
+1. Correctness and safety
+2. Official SDK alignment
+3. Clarity and predictability
+4. Backward compatibility
+5. Composability
+6. Developer convenience
+7. Implementation cleverness
+
+## Using this document
+
+Every issue, pull request, architectural decision, and release should reinforce this product vision. Changes that do not fit should be reshaped or kept outside the core package.


### PR DESCRIPTION
Replaces conflicted PR #110 with a current-main version of the product vision.

- defines mission, target users, non-goals, and principles
- establishes API and quality expectations
- adds a reusable feature acceptance test

Supersedes #110.