### PR TITLE
test: verify the package-root public API contract

### DIFF
--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -1,0 +1,14 @@
+"""Regression tests for the supported package-root API."""
+
+import openai_sdk_helpers
+
+
+def test_public_api_exports_are_unique() -> None:
+    """Keep the supported root API deterministic."""
+    assert len(openai_sdk_helpers.__all__) == len(set(openai_sdk_helpers.__all__))
+
+
+def test_public_api_exports_are_importable() -> None:
+    """Ensure each supported package-root symbol resolves."""
+    for name in openai_sdk_helpers.__all__:
+        assert getattr(openai_sdk_helpers, name) is not None


### PR DESCRIPTION
Implements #117.

- verifies every declared package-root export resolves
- prevents duplicate public symbols
- adds a regression guard against accidental API drift