### PR TITLE
Define and lock the supported package-root API

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,146 @@
+# Supported package-root API
+
+The names below are the intentional public API exposed from
+`openai_sdk_helpers`. They can be imported directly from the package root.
+Submodule imports remain available, but they are not covered by this package-root
+compatibility contract unless listed here.
+
+## Environment and configuration
+
+- `get_data_path`
+- `OpenAISettings`
+- `build_openai_settings`
+
+## Async helpers
+
+- `run_coroutine_thread_safe`
+- `run_coroutine_with_fallback`
+
+## Errors
+
+- `OpenAISDKError`
+- `ConfigurationError`
+- `PromptNotFoundError`
+- `AgentExecutionError`
+- `VectorStorageError`
+- `ToolExecutionError`
+- `ResponseGenerationError`
+- `InputValidationError`
+- `AsyncExecutionError`
+- `ResourceCleanupError`
+- `ExtractionError`
+
+## Input validation
+
+- `validate_non_empty_string`
+- `validate_max_length`
+- `validate_url_format`
+- `validate_dict_mapping`
+- `validate_list_items`
+- `validate_choice`
+- `validate_safe_path`
+
+## Structures and orchestration
+
+- `StructureBase`
+- `SchemaOptions`
+- `spec_field`
+- `SummaryStructure`
+- `PromptStructure`
+- `AgentBlueprint`
+- `TaskStructure`
+- `PlanStructure`
+- `ExtendedSummaryStructure`
+- `WebSearchStructure`
+- `VectorSearchStructure`
+- `ValidationResultStructure`
+- `AnnotatedDocumentStructure`
+- `AttributeStructure`
+- `DocumentStructure`
+- `ExampleDataStructure`
+- `ExtractionStructure`
+- `create_plan`
+- `execute_task`
+- `execute_plan`
+
+## Prompts, files, and vector storage
+
+- `PromptRenderer`
+- `FilesAPIManager`
+- `FilePurpose`
+- `VectorStorage`
+- `VectorStorageFileInfo`
+- `VectorStorageFileStats`
+
+## Agents
+
+- `AgentEnum`
+- `AgentBase`
+- `AgentConfiguration`
+- `CoordinatorAgent`
+- `ExtractorAgent`
+- `SummarizerAgent`
+- `TranslatorAgent`
+- `ValidatorAgent`
+- `VectorAgentSearch`
+- `WebAgentSearch`
+
+## Responses API helpers
+
+- `ResponseBase`
+- `ResponseMessage`
+- `ResponseMessages`
+- `ResponseToolCall`
+- `ResponseConfiguration`
+- `ResponseRegistry`
+- `get_default_registry`
+- `attach_vector_store`
+- `TaxonomyClassifierResponse`
+- `classify_taxonomy_response`
+- `TranslatorResponse`
+- `translate_response`
+- `open_websocket_connection`
+- `build_response_create_event`
+- `send_response_create`
+
+## Tool helpers
+
+- `tool_handler_factory`
+- `StructureType`
+- `ToolHandler`
+- `ToolHandlerRegistration`
+- `ToolSpec`
+- `build_tool_definition_list`
+
+## Output validation
+
+- `ValidationResult`
+- `ValidationRule`
+- `JSONSchemaValidator`
+- `SemanticValidator`
+- `LengthValidator`
+- `OutputValidator`
+- `validate_output`
+
+## LangExtract helpers
+
+- `LangExtractAdapter`
+- `build_langextract_adapter`
+
+## Extraction helpers
+
+- `DocumentExtractor`
+- `EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS`
+- `EXTRACTOR_CONFIG_GENERATOR`
+- `PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS`
+- `generate_document_extractor_config`
+- `generate_document_extractor_config_with_agent`
+- `optimize_extractor_prompt`
+- `optimize_extractor_prompt_with_agent`
+
+## Compatibility policy
+
+The package-root export list is defined by `openai_sdk_helpers.__all__` and is
+covered by regression tests. Removing or renaming one of these names is a
+breaking API change and must follow the project's deprecation and semantic
+versioning policy.

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,121 @@
+"""Regression tests for the supported package-root API."""
+
+from __future__ import annotations
+
+import openai_sdk_helpers
+
+
+EXPECTED_PUBLIC_API = (
+    "get_data_path",
+    "run_coroutine_thread_safe",
+    "run_coroutine_with_fallback",
+    "OpenAISDKError",
+    "ConfigurationError",
+    "PromptNotFoundError",
+    "AgentExecutionError",
+    "VectorStorageError",
+    "ToolExecutionError",
+    "ResponseGenerationError",
+    "InputValidationError",
+    "AsyncExecutionError",
+    "ResourceCleanupError",
+    "ExtractionError",
+    "validate_non_empty_string",
+    "validate_max_length",
+    "validate_url_format",
+    "validate_dict_mapping",
+    "validate_list_items",
+    "validate_choice",
+    "validate_safe_path",
+    "StructureBase",
+    "SchemaOptions",
+    "spec_field",
+    "PromptRenderer",
+    "OpenAISettings",
+    "FilesAPIManager",
+    "FilePurpose",
+    "VectorStorage",
+    "VectorStorageFileInfo",
+    "VectorStorageFileStats",
+    "SummaryStructure",
+    "PromptStructure",
+    "AgentBlueprint",
+    "TaskStructure",
+    "PlanStructure",
+    "AgentEnum",
+    "AgentBase",
+    "AgentConfiguration",
+    "CoordinatorAgent",
+    "ExtractorAgent",
+    "SummarizerAgent",
+    "TranslatorAgent",
+    "ValidatorAgent",
+    "VectorAgentSearch",
+    "WebAgentSearch",
+    "ExtendedSummaryStructure",
+    "WebSearchStructure",
+    "VectorSearchStructure",
+    "ValidationResultStructure",
+    "AnnotatedDocumentStructure",
+    "AttributeStructure",
+    "DocumentStructure",
+    "ExampleDataStructure",
+    "ExtractionStructure",
+    "ResponseBase",
+    "ResponseMessage",
+    "ResponseMessages",
+    "ResponseToolCall",
+    "ResponseConfiguration",
+    "ResponseRegistry",
+    "get_default_registry",
+    "attach_vector_store",
+    "TaxonomyClassifierResponse",
+    "classify_taxonomy_response",
+    "TranslatorResponse",
+    "translate_response",
+    "open_websocket_connection",
+    "build_response_create_event",
+    "send_response_create",
+    "tool_handler_factory",
+    "StructureType",
+    "ToolHandler",
+    "ToolHandlerRegistration",
+    "ToolSpec",
+    "build_tool_definition_list",
+    "build_openai_settings",
+    "create_plan",
+    "execute_task",
+    "execute_plan",
+    "ValidationResult",
+    "ValidationRule",
+    "JSONSchemaValidator",
+    "SemanticValidator",
+    "LengthValidator",
+    "OutputValidator",
+    "validate_output",
+    "LangExtractAdapter",
+    "build_langextract_adapter",
+    "DocumentExtractor",
+    "EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS",
+    "EXTRACTOR_CONFIG_GENERATOR",
+    "PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS",
+    "generate_document_extractor_config",
+    "generate_document_extractor_config_with_agent",
+    "optimize_extractor_prompt",
+    "optimize_extractor_prompt_with_agent",
+)
+
+
+def test_package_root_exports_are_explicit_and_stable() -> None:
+    """Keep the supported package-root exports intentional and ordered."""
+    assert tuple(openai_sdk_helpers.__all__) == EXPECTED_PUBLIC_API
+    assert len(openai_sdk_helpers.__all__) == len(set(openai_sdk_helpers.__all__))
+
+
+def test_every_public_export_is_importable() -> None:
+    """Ensure every declared public name exists on the package root."""
+    missing = [
+        name for name in openai_sdk_helpers.__all__ if not hasattr(openai_sdk_helpers, name)
+    ]
+
+    assert missing == []


### PR DESCRIPTION
Closes #117.

## Summary
- document every intentional `openai_sdk_helpers` package-root export
- define the compatibility policy for package-root imports
- add regression tests that lock `__all__`, reject duplicates, and verify every declared export exists

## Validation
GitHub Actions must pass formatting, docstring, typing, tests, coverage, and package installation checks before merge.