### PR TITLE
feat: add first-class Codex plugin surface

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,44 @@
 # Roadmap
 
-The roadmap is managed through GitHub issues and milestones.
+Every roadmap item must support `PRODUCT.md` and preserve a small, typed, predictable public API.
 
-Priorities are reliability, API consistency, documentation, testing, and stable releases.
+## Now — Codex plugin foundation
 
-Every item must support `PRODUCT.md`.
+- [x] Define the minimal typed plugin protocol.
+- [x] Add deterministic plugin and command registration.
+- [x] Support package discovery through `openai_sdk_helpers.codex` entry points.
+- [x] Add focused registry tests.
+- [ ] Export the stable Codex surface from the package root.
+- [ ] Add lifecycle hooks for startup and shutdown.
+- [ ] Add async command support without duplicating the synchronous API.
+- [ ] Add a runnable first-plugin example and packaging guide.
+
+## Next — production hardening
+
+- [ ] Define plugin compatibility and deprecation policy.
+- [ ] Add isolated plugin failure reporting.
+- [ ] Add structured plugin metadata and capability inspection.
+- [ ] Add CLI commands to list plugins and commands.
+- [ ] Test installed entry-point discovery end to end.
+- [ ] Add documentation and migration guidance.
+
+## Later — official integrations
+
+Official integrations should remain optional and use the same plugin contract:
+
+- Responses
+- Agents
+- MCP
+- File Search and Vector Stores
+- Realtime
+- Images and Audio
+
+## Release gates
+
+A milestone is complete only when:
+
+1. Tests, type checks, docstring checks, and package builds pass.
+2. Public APIs are documented with runnable examples.
+3. Backward compatibility impact is explicit.
+4. No OpenAI API call is hidden behind surprising defaults.
+5. The core package remains usable without optional integrations.

--- a/src/openai_sdk_helpers/codex/__init__.py
+++ b/src/openai_sdk_helpers/codex/__init__.py
@@ -1,0 +1,12 @@
+"""First-class, lightweight Codex plugin surface."""
+
+from .plugin import CodexCommand, CodexPlugin, CodexPluginContext
+from .registry import CODEX_PLUGIN_ENTRY_POINT, CodexPluginRegistry
+
+__all__ = [
+    "CODEX_PLUGIN_ENTRY_POINT",
+    "CodexCommand",
+    "CodexPlugin",
+    "CodexPluginContext",
+    "CodexPluginRegistry",
+]

--- a/src/openai_sdk_helpers/codex/plugin.py
+++ b/src/openai_sdk_helpers/codex/plugin.py
@@ -1,0 +1,61 @@
+"""Typed contracts for lightweight Codex plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Protocol, runtime_checkable
+
+CodexCommand = Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class CodexPluginContext:
+    """Context exposed to plugins during registration.
+
+    Parameters
+    ----------
+    commands
+        Mutable command mapping owned by the registry.
+    metadata
+        Shared read-only metadata for plugin setup.
+    """
+
+    commands: dict[str, CodexCommand]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def add_command(self, name: str, command: CodexCommand) -> None:
+        """Register a command under a unique non-empty name.
+
+        Parameters
+        ----------
+        name
+            Public command name.
+        command
+            Callable invoked for the command.
+
+        Raises
+        ------
+        ValueError
+            If the name is empty or already registered.
+        TypeError
+            If ``command`` is not callable.
+        """
+
+        normalized = name.strip()
+        if not normalized:
+            raise ValueError("Command name must not be empty.")
+        if normalized in self.commands:
+            raise ValueError(f"Command already registered: {normalized}")
+        if not callable(command):
+            raise TypeError("Command must be callable.")
+        self.commands[normalized] = command
+
+
+@runtime_checkable
+class CodexPlugin(Protocol):
+    """Minimal protocol implemented by first-class Codex plugins."""
+
+    name: str
+
+    def setup(self, context: CodexPluginContext) -> None:
+        """Register commands and capabilities on ``context``."""

--- a/src/openai_sdk_helpers/codex/registry.py
+++ b/src/openai_sdk_helpers/codex/registry.py
@@ -1,0 +1,108 @@
+"""Registration and discovery for Codex plugins."""
+
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint, entry_points
+from typing import Any, Iterable, Mapping
+
+from .plugin import CodexCommand, CodexPlugin, CodexPluginContext
+
+CODEX_PLUGIN_ENTRY_POINT = "openai_sdk_helpers.codex"
+
+
+class CodexPluginRegistry:
+    """Small, deterministic registry for Codex plugins and commands.
+
+    Parameters
+    ----------
+    metadata
+        Shared metadata exposed to every plugin during setup.
+    """
+
+    def __init__(self, *, metadata: Mapping[str, Any] | None = None) -> None:
+        self._plugins: dict[str, CodexPlugin] = {}
+        self._commands: dict[str, CodexCommand] = {}
+        self._context = CodexPluginContext(
+            commands=self._commands,
+            metadata={} if metadata is None else dict(metadata),
+        )
+
+    @property
+    def plugin_names(self) -> tuple[str, ...]:
+        """Return registered plugin names in registration order."""
+
+        return tuple(self._plugins)
+
+    @property
+    def command_names(self) -> tuple[str, ...]:
+        """Return registered command names in registration order."""
+
+        return tuple(self._commands)
+
+    def register(self, plugin: CodexPlugin) -> CodexPlugin:
+        """Register and initialize one plugin.
+
+        Parameters
+        ----------
+        plugin
+            Object implementing :class:`CodexPlugin`.
+
+        Returns
+        -------
+        CodexPlugin
+            The registered plugin.
+
+        Raises
+        ------
+        TypeError
+            If the object does not implement the plugin protocol.
+        ValueError
+            If its name is empty or already registered.
+        """
+
+        if not isinstance(plugin, CodexPlugin):
+            raise TypeError("Plugin must define a name and setup(context).")
+        name = plugin.name.strip()
+        if not name:
+            raise ValueError("Plugin name must not be empty.")
+        if name in self._plugins:
+            raise ValueError(f"Plugin already registered: {name}")
+        plugin.setup(self._context)
+        self._plugins[name] = plugin
+        return plugin
+
+    def get_plugin(self, name: str) -> CodexPlugin:
+        """Return a registered plugin by name."""
+
+        return self._plugins[name]
+
+    def run(self, command: str, /, *args: Any, **kwargs: Any) -> Any:
+        """Execute a registered command."""
+
+        try:
+            handler = self._commands[command]
+        except KeyError as exc:
+            raise KeyError(f"Unknown Codex command: {command}") from exc
+        return handler(*args, **kwargs)
+
+    def discover(self, group: str = CODEX_PLUGIN_ENTRY_POINT) -> tuple[CodexPlugin, ...]:
+        """Load and register plugins exposed through package entry points."""
+
+        discovered = entry_points().select(group=group)
+        return self.load_entry_points(discovered)
+
+    def load_entry_points(
+        self, entry_point_values: Iterable[EntryPoint]
+    ) -> tuple[CodexPlugin, ...]:
+        """Load plugins from explicit entry points.
+
+        This separate method keeps discovery easy to test without installed
+        distributions.
+        """
+
+        loaded: list[CodexPlugin] = []
+        for entry_point in entry_point_values:
+            candidate = entry_point.load()
+            plugin = candidate() if isinstance(candidate, type) else candidate
+            loaded.append(self.register(plugin))
+        return tuple(loaded)

--- a/tests/test_codex_plugins.py
+++ b/tests/test_codex_plugins.py
@@ -1,0 +1,66 @@
+"""Tests for the Codex plugin surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from openai_sdk_helpers.codex import CodexPluginContext, CodexPluginRegistry
+
+
+class GreetingPlugin:
+    """Small test plugin."""
+
+    name = "greeting"
+
+    def setup(self, context: CodexPluginContext) -> None:
+        """Register a greeting command."""
+
+        prefix = str(context.metadata.get("prefix", "hello"))
+        context.add_command("greet", lambda name: f"{prefix} {name}")
+
+
+def test_register_and_run_plugin_command() -> None:
+    registry = CodexPluginRegistry(metadata={"prefix": "hi"})
+
+    plugin = registry.register(GreetingPlugin())
+
+    assert plugin.name == "greeting"
+    assert registry.plugin_names == ("greeting",)
+    assert registry.command_names == ("greet",)
+    assert registry.run("greet", "Codex") == "hi Codex"
+
+
+def test_duplicate_plugin_is_rejected() -> None:
+    registry = CodexPluginRegistry()
+    registry.register(GreetingPlugin())
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(GreetingPlugin())
+
+
+def test_duplicate_command_is_rejected() -> None:
+    registry = CodexPluginRegistry()
+    registry.register(GreetingPlugin())
+
+    class DuplicateCommandPlugin:
+        name = "duplicate"
+
+        def setup(self, context: CodexPluginContext) -> None:
+            context.add_command("greet", lambda: None)
+
+    with pytest.raises(ValueError, match="Command already registered"):
+        registry.register(DuplicateCommandPlugin())
+
+
+def test_unknown_command_has_clear_error() -> None:
+    registry = CodexPluginRegistry()
+
+    with pytest.raises(KeyError, match="Unknown Codex command"):
+        registry.run("missing")
+
+
+def test_invalid_plugin_is_rejected() -> None:
+    registry = CodexPluginRegistry()
+
+    with pytest.raises(TypeError, match="Plugin must define"):
+        registry.register(object())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- add a minimal typed `CodexPlugin` protocol and setup context
- add deterministic plugin and command registration
- support installed plugin discovery through the `openai_sdk_helpers.codex` entry-point group
- add focused registry tests and clear duplicate/unknown-command errors
- replace the placeholder roadmap with an executable Codex-first plan

## Design

The surface stays deliberately small: plugins expose a `name` and `setup(context)`, while the registry owns commands and discovery. It has no OpenAI runtime dependency and does not hide API calls.

## Validation

- new unit coverage in `tests/test_codex_plugins.py`
- existing CI expected to run pytest, type checks, and style checks
