### PR TITLE
feat: complete Codex plugin foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: pydocstyle src
 
       - name: Format check with black
-        run: black --diff --check .
+        run: black --check .
 
       - name: Type check with pyright
         run: pyright src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: pydocstyle src
 
       - name: Format check with black
-        run: black --check .
+        run: black --diff --check .
 
       - name: Type check with pyright
         run: pyright src

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,25 +2,26 @@
 
 Every roadmap item must support `PRODUCT.md` and preserve a small, typed, predictable public API.
 
-## Now — Codex plugin foundation
+## Completed — Codex plugin foundation
 
 - [x] Define the minimal typed plugin protocol.
 - [x] Add deterministic plugin and command registration.
 - [x] Support package discovery through `openai_sdk_helpers.codex` entry points.
 - [x] Add focused registry tests.
-- [ ] Export the stable Codex surface from the package root.
-- [ ] Add lifecycle hooks for startup and shutdown.
-- [ ] Add async command support without duplicating the synchronous API.
-- [ ] Add a runnable first-plugin example and packaging guide.
+- [x] Export the stable Codex surface from the package root.
+- [x] Add lifecycle hooks for startup and shutdown.
+- [x] Add async command support without duplicating the synchronous API.
+- [x] Add atomic rollback when plugin setup fails.
+- [x] Add a runnable first-plugin example and packaging guide.
 
 ## Next — production hardening
 
 - [ ] Define plugin compatibility and deprecation policy.
-- [ ] Add isolated plugin failure reporting.
+- [ ] Add isolated discovery failure reporting.
 - [ ] Add structured plugin metadata and capability inspection.
 - [ ] Add CLI commands to list plugins and commands.
 - [ ] Test installed entry-point discovery end to end.
-- [ ] Add documentation and migration guidance.
+- [ ] Add migration guidance before the next minor release.
 
 ## Later — official integrations
 

--- a/docs/codex-plugins.md
+++ b/docs/codex-plugins.md
@@ -1,0 +1,67 @@
+# Codex plugins
+
+`openai-sdk-helpers` provides a deliberately small plugin contract for reusable Codex workflows. The registry handles discovery, command routing, lifecycle hooks, and sync or async execution without hiding OpenAI SDK calls.
+
+## Create a plugin
+
+```python
+from openai_sdk_helpers import CodexPluginContext
+
+
+class MyPlugin:
+    name = "my-plugin"
+
+    def setup(self, context: CodexPluginContext) -> None:
+        context.add_command("hello", lambda name: f"Hello, {name}!")
+
+    async def startup(self) -> None:
+        # Allocate optional resources.
+        pass
+
+    async def shutdown(self) -> None:
+        # Release optional resources.
+        pass
+```
+
+Only `name` and `setup(context)` are required. `startup()` and `shutdown()` are optional and may be synchronous or asynchronous.
+
+## Run plugins directly
+
+```python
+from openai_sdk_helpers import CodexPluginRegistry
+
+registry = CodexPluginRegistry(metadata={"environment": "production"})
+registry.register(MyPlugin())
+
+async with registry:
+    result = await registry.run_async("hello", "Codex")
+```
+
+Use `run()` for synchronous commands. It intentionally returns an awaitable unchanged when the registered command is asynchronous. Use `run_async()` when command type is not known by the caller.
+
+## Publish an installable plugin
+
+Declare the plugin in the package's `pyproject.toml`:
+
+```toml
+[project.entry-points."openai_sdk_helpers.codex"]
+my-plugin = "my_package.plugin:MyPlugin"
+```
+
+Then discover installed plugins:
+
+```python
+registry = CodexPluginRegistry()
+registry.discover()
+```
+
+An entry point may expose either a plugin instance or a plugin class with a no-argument constructor.
+
+## Registration guarantees
+
+- Plugin and command names must be unique and non-empty.
+- Plugin setup is atomic: commands added by a failing setup are rolled back.
+- Plugins cannot be added after registry startup.
+- Startup runs in registration order.
+- Shutdown runs in reverse registration order.
+- Repeated startup and shutdown calls are safe no-ops.

--- a/examples/codex_plugin.py
+++ b/examples/codex_plugin.py
@@ -1,0 +1,44 @@
+"""Minimal first-class Codex plugin example."""
+
+from __future__ import annotations
+
+import asyncio
+
+from openai_sdk_helpers import CodexPluginContext, CodexPluginRegistry
+
+
+class GreetingPlugin:
+    """Register synchronous and asynchronous greeting commands."""
+
+    name = "greeting"
+
+    def setup(self, context: CodexPluginContext) -> None:
+        """Register commands exposed by this plugin."""
+
+        context.add_command("greet", lambda name: f"Hello, {name}!")
+
+        async def greet_async(name: str) -> str:
+            return f"Hello asynchronously, {name}!"
+
+        context.add_command("greet_async", greet_async)
+
+    async def startup(self) -> None:
+        """Prepare optional plugin resources."""
+
+    async def shutdown(self) -> None:
+        """Release optional plugin resources."""
+
+
+async def main() -> None:
+    """Run the example plugin."""
+
+    registry = CodexPluginRegistry()
+    registry.register(GreetingPlugin())
+
+    async with registry:
+        print(registry.run("greet", "Codex"))
+        print(await registry.run_async("greet_async", "Codex"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/openai_sdk_helpers/__init__.py
+++ b/src/openai_sdk_helpers/__init__.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from .codex import (
+    CODEX_PLUGIN_ENTRY_POINT,
+    CodexCommand,
+    CodexPlugin,
+    CodexPluginContext,
+    CodexPluginRegistry,
+)
 from .environment import get_data_path
 from .utils.async_utils import run_coroutine_thread_safe, run_coroutine_with_fallback
 
@@ -114,6 +121,12 @@ from .extract import (
 )
 
 __all__ = [
+    # Codex plugins
+    "CODEX_PLUGIN_ENTRY_POINT",
+    "CodexCommand",
+    "CodexPlugin",
+    "CodexPluginContext",
+    "CodexPluginRegistry",
     # Environment utilities
     "get_data_path",
     # Async utilities

--- a/src/openai_sdk_helpers/codex/plugin.py
+++ b/src/openai_sdk_helpers/codex/plugin.py
@@ -40,7 +40,6 @@ class CodexPluginContext:
         TypeError
             If ``command`` is not callable.
         """
-
         normalized = name.strip()
         if not normalized:
             raise ValueError("Command name must not be empty.")

--- a/src/openai_sdk_helpers/codex/registry.py
+++ b/src/openai_sdk_helpers/codex/registry.py
@@ -32,19 +32,16 @@ class CodexPluginRegistry:
     @property
     def plugin_names(self) -> tuple[str, ...]:
         """Return registered plugin names in registration order."""
-
         return tuple(self._plugins)
 
     @property
     def command_names(self) -> tuple[str, ...]:
         """Return registered command names in registration order."""
-
         return tuple(self._commands)
 
     @property
     def started(self) -> bool:
         """Return whether plugin startup hooks have completed."""
-
         return self._started
 
     def register(self, plugin: CodexPlugin) -> CodexPlugin:
@@ -69,7 +66,6 @@ class CodexPluginRegistry:
         RuntimeError
             If registration is attempted after startup.
         """
-
         if self._started:
             raise RuntimeError("Plugins cannot be registered after startup.")
         if not isinstance(plugin, CodexPlugin):
@@ -93,7 +89,6 @@ class CodexPluginRegistry:
 
     def get_plugin(self, name: str) -> CodexPlugin:
         """Return a registered plugin by name."""
-
         return self._plugins[name]
 
     def run(self, command: str, /, *args: Any, **kwargs: Any) -> Any:
@@ -103,7 +98,6 @@ class CodexPluginRegistry:
         caller wants one API that supports both synchronous and asynchronous
         commands.
         """
-
         try:
             handler = self._commands[command]
         except KeyError as exc:
@@ -112,7 +106,6 @@ class CodexPluginRegistry:
 
     async def run_async(self, command: str, /, *args: Any, **kwargs: Any) -> Any:
         """Execute a command and await its result when necessary."""
-
         result = self.run(command, *args, **kwargs)
         if inspect.isawaitable(result):
             return await result
@@ -120,7 +113,6 @@ class CodexPluginRegistry:
 
     async def startup(self) -> None:
         """Run optional plugin startup hooks in registration order."""
-
         if self._started:
             return
         for plugin in self._plugins.values():
@@ -129,7 +121,6 @@ class CodexPluginRegistry:
 
     async def shutdown(self) -> None:
         """Run optional plugin shutdown hooks in reverse registration order."""
-
         if not self._started:
             return
         for plugin in reversed(tuple(self._plugins.values())):
@@ -138,18 +129,15 @@ class CodexPluginRegistry:
 
     async def __aenter__(self) -> CodexPluginRegistry:
         """Start plugins and return this registry."""
-
         await self.startup()
         return self
 
     async def __aexit__(self, *_: object) -> None:
         """Shut plugins down when leaving an async context."""
-
         await self.shutdown()
 
     def discover(self, group: str = CODEX_PLUGIN_ENTRY_POINT) -> tuple[CodexPlugin, ...]:
         """Load and register plugins exposed through package entry points."""
-
         discovered = entry_points().select(group=group)
         return self.load_entry_points(discovered)
 
@@ -161,7 +149,6 @@ class CodexPluginRegistry:
         This separate method keeps discovery easy to test without installed
         distributions.
         """
-
         loaded: list[CodexPlugin] = []
         for entry_point in entry_point_values:
             candidate = entry_point.load()

--- a/src/openai_sdk_helpers/codex/registry.py
+++ b/src/openai_sdk_helpers/codex/registry.py
@@ -136,7 +136,9 @@ class CodexPluginRegistry:
         """Shut plugins down when leaving an async context."""
         await self.shutdown()
 
-    def discover(self, group: str = CODEX_PLUGIN_ENTRY_POINT) -> tuple[CodexPlugin, ...]:
+    def discover(
+        self, group: str = CODEX_PLUGIN_ENTRY_POINT
+    ) -> tuple[CodexPlugin, ...]:
         """Load and register plugins exposed through package entry points."""
         discovered = entry_points().select(group=group)
         return self.load_entry_points(discovered)

--- a/src/openai_sdk_helpers/codex/registry.py
+++ b/src/openai_sdk_helpers/codex/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from importlib.metadata import EntryPoint, entry_points
 from typing import Any, Iterable, Mapping
 
@@ -26,6 +27,7 @@ class CodexPluginRegistry:
             commands=self._commands,
             metadata={} if metadata is None else dict(metadata),
         )
+        self._started = False
 
     @property
     def plugin_names(self) -> tuple[str, ...]:
@@ -39,8 +41,14 @@ class CodexPluginRegistry:
 
         return tuple(self._commands)
 
+    @property
+    def started(self) -> bool:
+        """Return whether plugin startup hooks have completed."""
+
+        return self._started
+
     def register(self, plugin: CodexPlugin) -> CodexPlugin:
-        """Register and initialize one plugin.
+        """Register and initialize one plugin atomically.
 
         Parameters
         ----------
@@ -58,8 +66,12 @@ class CodexPluginRegistry:
             If the object does not implement the plugin protocol.
         ValueError
             If its name is empty or already registered.
+        RuntimeError
+            If registration is attempted after startup.
         """
 
+        if self._started:
+            raise RuntimeError("Plugins cannot be registered after startup.")
         if not isinstance(plugin, CodexPlugin):
             raise TypeError("Plugin must define a name and setup(context).")
         name = plugin.name.strip()
@@ -67,7 +79,15 @@ class CodexPluginRegistry:
             raise ValueError("Plugin name must not be empty.")
         if name in self._plugins:
             raise ValueError(f"Plugin already registered: {name}")
-        plugin.setup(self._context)
+
+        previous_commands = dict(self._commands)
+        try:
+            plugin.setup(self._context)
+        except Exception:
+            self._commands.clear()
+            self._commands.update(previous_commands)
+            raise
+
         self._plugins[name] = plugin
         return plugin
 
@@ -77,13 +97,55 @@ class CodexPluginRegistry:
         return self._plugins[name]
 
     def run(self, command: str, /, *args: Any, **kwargs: Any) -> Any:
-        """Execute a registered command."""
+        """Execute a registered command.
+
+        Async commands return an awaitable. Use :meth:`run_async` when the
+        caller wants one API that supports both synchronous and asynchronous
+        commands.
+        """
 
         try:
             handler = self._commands[command]
         except KeyError as exc:
             raise KeyError(f"Unknown Codex command: {command}") from exc
         return handler(*args, **kwargs)
+
+    async def run_async(self, command: str, /, *args: Any, **kwargs: Any) -> Any:
+        """Execute a command and await its result when necessary."""
+
+        result = self.run(command, *args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    async def startup(self) -> None:
+        """Run optional plugin startup hooks in registration order."""
+
+        if self._started:
+            return
+        for plugin in self._plugins.values():
+            await self._call_hook(plugin, "startup")
+        self._started = True
+
+    async def shutdown(self) -> None:
+        """Run optional plugin shutdown hooks in reverse registration order."""
+
+        if not self._started:
+            return
+        for plugin in reversed(tuple(self._plugins.values())):
+            await self._call_hook(plugin, "shutdown")
+        self._started = False
+
+    async def __aenter__(self) -> CodexPluginRegistry:
+        """Start plugins and return this registry."""
+
+        await self.startup()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Shut plugins down when leaving an async context."""
+
+        await self.shutdown()
 
     def discover(self, group: str = CODEX_PLUGIN_ENTRY_POINT) -> tuple[CodexPlugin, ...]:
         """Load and register plugins exposed through package entry points."""
@@ -106,3 +168,12 @@ class CodexPluginRegistry:
             plugin = candidate() if isinstance(candidate, type) else candidate
             loaded.append(self.register(plugin))
         return tuple(loaded)
+
+    @staticmethod
+    async def _call_hook(plugin: CodexPlugin, hook_name: str) -> None:
+        hook = getattr(plugin, hook_name, None)
+        if hook is None:
+            return
+        result = hook()
+        if inspect.isawaitable(result):
+            await result

--- a/tests/test_codex_plugins.py
+++ b/tests/test_codex_plugins.py
@@ -30,6 +30,79 @@ def test_register_and_run_plugin_command() -> None:
     assert registry.run("greet", "Codex") == "hi Codex"
 
 
+@pytest.mark.asyncio
+async def test_run_async_supports_sync_and_async_commands() -> None:
+    registry = CodexPluginRegistry()
+
+    class MixedPlugin:
+        name = "mixed"
+
+        def setup(self, context: CodexPluginContext) -> None:
+            context.add_command("sync", lambda value: value + 1)
+
+            async def async_command(value: int) -> int:
+                return value + 2
+
+            context.add_command("async", async_command)
+
+    registry.register(MixedPlugin())
+
+    assert await registry.run_async("sync", 1) == 2
+    assert await registry.run_async("async", 1) == 3
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_hooks_and_context_manager() -> None:
+    events: list[str] = []
+    registry = CodexPluginRegistry()
+
+    class LifecyclePlugin:
+        name = "lifecycle"
+
+        def setup(self, context: CodexPluginContext) -> None:
+            context.add_command("status", lambda: "ready")
+
+        async def startup(self) -> None:
+            events.append("start")
+
+        def shutdown(self) -> None:
+            events.append("stop")
+
+    registry.register(LifecyclePlugin())
+
+    async with registry:
+        assert registry.started is True
+        assert registry.run("status") == "ready"
+
+    assert registry.started is False
+    assert events == ["start", "stop"]
+
+
+def test_failed_setup_rolls_back_registered_commands() -> None:
+    registry = CodexPluginRegistry()
+
+    class BrokenPlugin:
+        name = "broken"
+
+        def setup(self, context: CodexPluginContext) -> None:
+            context.add_command("temporary", lambda: None)
+            raise RuntimeError("setup failed")
+
+    with pytest.raises(RuntimeError, match="setup failed"):
+        registry.register(BrokenPlugin())
+
+    assert registry.plugin_names == ()
+    assert registry.command_names == ()
+
+
+def test_registration_after_startup_is_rejected() -> None:
+    registry = CodexPluginRegistry()
+    registry._started = True
+
+    with pytest.raises(RuntimeError, match="after startup"):
+        registry.register(GreetingPlugin())
+
+
 def test_duplicate_plugin_is_rejected() -> None:
     registry = CodexPluginRegistry()
     registry.register(GreetingPlugin())

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -6,6 +6,11 @@ import openai_sdk_helpers
 
 
 EXPECTED_PUBLIC_API = (
+    "CODEX_PLUGIN_ENTRY_POINT",
+    "CodexCommand",
+    "CodexPlugin",
+    "CodexPluginContext",
+    "CodexPluginRegistry",
     "get_data_path",
     "run_coroutine_thread_safe",
     "run_coroutine_with_fallback",
@@ -114,8 +119,6 @@ def test_package_root_exports_are_explicit_and_stable() -> None:
 
 def test_every_public_export_is_importable() -> None:
     """Ensure every declared public name exists on the package root."""
-    missing = [
-        name for name in openai_sdk_helpers.__all__ if not hasattr(openai_sdk_helpers, name)
-    ]
+    missing = [name for name in openai_sdk_helpers.__all__ if not hasattr(openai_sdk_helpers, name)]
 
     assert missing == []

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import openai_sdk_helpers
 
-
 EXPECTED_PUBLIC_API = (
     "CODEX_PLUGIN_ENTRY_POINT",
     "CodexCommand",
@@ -120,7 +119,9 @@ def test_package_root_exports_are_explicit_and_stable() -> None:
 def test_every_public_export_is_importable() -> None:
     """Ensure every declared public name exists on the package root."""
     missing = [
-        name for name in openai_sdk_helpers.__all__ if not hasattr(openai_sdk_helpers, name)
+        name
+        for name in openai_sdk_helpers.__all__
+        if not hasattr(openai_sdk_helpers, name)
     ]
 
     assert missing == []

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -120,9 +120,7 @@ def test_package_root_exports_are_explicit_and_stable() -> None:
 def test_every_public_export_is_importable() -> None:
     """Ensure every declared public name exists on the package root."""
     missing = [
-        name
-        for name in openai_sdk_helpers.__all__
-        if not hasattr(openai_sdk_helpers, name)
+        name for name in openai_sdk_helpers.__all__ if not hasattr(openai_sdk_helpers, name)
     ]
 
     assert missing == []

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -119,6 +119,10 @@ def test_package_root_exports_are_explicit_and_stable() -> None:
 
 def test_every_public_export_is_importable() -> None:
     """Ensure every declared public name exists on the package root."""
-    missing = [name for name in openai_sdk_helpers.__all__ if not hasattr(openai_sdk_helpers, name)]
+    missing = [
+        name
+        for name in openai_sdk_helpers.__all__
+        if not hasattr(openai_sdk_helpers, name)
+    ]
 
     assert missing == []


### PR DESCRIPTION
## Summary

- export the Codex plugin API from the package root
- add sync/async command execution through one registry surface
- add optional startup and shutdown lifecycle hooks
- support async context-manager operation
- make plugin setup atomic with command rollback on failure
- prevent registry mutation after startup
- add a runnable example and installable entry-point packaging guide
- mark the Codex foundation milestone complete

## Validation coverage

- sync and async command execution
- lifecycle ordering and context-manager behavior
- failed setup rollback
- duplicate plugin and command rejection
- invalid plugin and unknown command errors

## Compatibility

The required plugin contract remains `name` plus `setup(context)`. Lifecycle hooks are optional, so existing plugins remain compatible.