### PR TITLE
feat: make openai-sdk-helpers a native Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "fatmambot33-openai-sdk-helpers",
+  "interface": {
+    "displayName": "OpenAI SDK Helpers"
+  },
+  "plugins": [
+    {
+      "name": "openai-sdk-helpers",
+      "source": {
+        "source": "local",
+        "path": "./plugins/openai-sdk-helpers"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/plugins/openai-sdk-helpers/.codex-plugin/plugin.json
+++ b/plugins/openai-sdk-helpers/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "openai-sdk-helpers",
+  "version": "0.7.4",
+  "description": "Build OpenAI SDK workflows with reusable typed helpers in Codex.",
+  "author": {
+    "name": "openai-sdk-helpers maintainers",
+    "url": "https://github.com/fatmambot33"
+  },
+  "homepage": "https://github.com/fatmambot33/openai-sdk-helpers",
+  "repository": "https://github.com/fatmambot33/openai-sdk-helpers",
+  "license": "MIT",
+  "keywords": ["openai", "sdk", "agents", "responses", "codex", "python"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "OpenAI SDK Helpers",
+    "shortDescription": "Typed OpenAI SDK workflows for Codex",
+    "longDescription": "Install openai-sdk-helpers from Git and use its typed prompts, agents, response helpers, validation, storage, and Codex command registry.",
+    "developerName": "openai-sdk-helpers maintainers",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write", "Interactive"],
+    "websiteURL": "https://github.com/fatmambot33/openai-sdk-helpers",
+    "defaultPrompt": [
+      "Build a typed Responses API workflow.",
+      "Create and validate an agent plan.",
+      "Inspect the available Codex commands."
+    ],
+    "brandColor": "#10A37F"
+  }
+}

--- a/plugins/openai-sdk-helpers/skills/openai-sdk-helpers/SKILL.md
+++ b/plugins/openai-sdk-helpers/skills/openai-sdk-helpers/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: openai-sdk-helpers
+description: Install and use openai-sdk-helpers from Git to build typed OpenAI Responses API, agent, prompt, validation, extraction, and vector storage workflows.
+---
+
+# OpenAI SDK Helpers
+
+## Setup
+
+Ensure the current Python environment has the repository version installed:
+
+```bash
+python -m pip install --upgrade "git+https://github.com/fatmambot33/openai-sdk-helpers.git"
+```
+
+Use the package's Codex registry and public typed helpers rather than recreating orchestration utilities.
+
+## Workflow
+
+1. Inspect the installed package version and public exports.
+2. Use `CodexPluginRegistry` to discover commands and capabilities.
+3. Prefer structured output models and validators for machine-consumed responses.
+4. Keep credentials in environment variables and never print secrets.
+5. Use the Responses API helpers for new OpenAI integrations.
+6. Run relevant tests and type checks after generated changes.
+
+## Example
+
+```python
+from openai_sdk_helpers import CodexPluginRegistry
+
+registry = CodexPluginRegistry()
+print(registry.list_commands())
+```
+
+Follow the repository's NumPy-style docstring, Pyright, Black, and pytest conventions when editing code.


### PR DESCRIPTION
## Summary

- add a repo-backed Codex marketplace
- add a validated `.codex-plugin/plugin.json` manifest
- add a reusable OpenAI SDK helper skill
- provide Git installation and Codex-registry guidance

## Install

```bash
codex plugin marketplace add fatmambot33/openai-sdk-helpers --ref main
codex plugin add openai-sdk-helpers@fatmambot33-openai-sdk-helpers
```
