### PR TITLE
feat: add local OpenAI credential wizard and doctor

### DIFF
--- a/plugins/openai-sdk-helpers/skills/openai-sdk-helpers/SKILL.md
+++ b/plugins/openai-sdk-helpers/skills/openai-sdk-helpers/SKILL.md
@@ -1,40 +1,15 @@
 ---
 name: openai-sdk-helpers
-description: Install and use openai-sdk-helpers from Git with OpenAI credentials loaded only from a local .env file for typed Responses API, agent, prompt, validation, extraction, and vector workflows.
+description: Install and use openai-sdk-helpers from Git with OpenAI credentials loaded only from a local .env file.
 ---
 
 # OpenAI SDK Helpers
 
 ## Local-only credential policy
 
-Use only credentials stored in the user's local project `.env`. Never request, upload, persist, or copy API keys into Codex, Git, plugin files, chat messages, hosted configuration, MCP URLs, or command history. Never print secret values.
+Use only credentials stored in the user's local project `.env`. Never request secret values in chat, upload them, print them, or copy them into Codex, Git, plugin files, hosted configuration, MCP URLs, or command history.
 
-Before the first OpenAI API operation:
-
-1. Check whether `.env` exists in the current working directory.
-2. If it is missing, copy the included template:
-
-```bash
-cp plugins/openai-sdk-helpers/.env.example .env
-```
-
-3. Ask the user to edit `.env` locally:
-
-```dotenv
-OPENAI_API_KEY=
-OPENAI_PROJECT=
-OPENAI_ORG_ID=
-```
-
-Only `OPENAI_API_KEY` is required. Project and organization values are optional.
-
-4. Ensure `.env` is ignored by Git. Add it to `.gitignore` when necessary.
-5. Verify only that required variable names are present and non-empty. Never display values.
-6. Stop before any network call until local configuration is complete.
-
-Load `.env` locally with `python-dotenv` or the package configuration path. Do not fall back to Codex-managed credentials, hosted secrets, remote secret stores, or keys supplied in prompts.
-
-## Setup
+## First-use setup
 
 Install the repository version locally:
 
@@ -42,19 +17,32 @@ Install the repository version locally:
 python -m pip install --upgrade "git+https://github.com/fatmambot33/openai-sdk-helpers.git"
 ```
 
-Use the package's Codex registry and typed helpers rather than recreating orchestration utilities.
+Before any OpenAI network operation, run:
+
+```bash
+openai-helpers-credentials doctor
+```
+
+When the check fails, guide the user through:
+
+```bash
+openai-helpers-credentials configure
+```
+
+The wizard securely prompts for `OPENAI_API_KEY` without echoing it and optionally accepts `OPENAI_PROJECT` and `OPENAI_ORG_ID`. It writes only to the current project's `.env`, applies restrictive permissions where supported, refuses accidental overwrites, and warns when Git-ignore protection is missing.
+
+Run the doctor again after setup. It validates file existence, required variable names, permissions, and `.gitignore` coverage without displaying credential values. Stop network operations until it passes.
+
+Use `--env-file PATH` only for a deliberate non-default local file. Never fall back to hosted secrets, Codex-managed credentials, remote secret stores, or credentials supplied in prompts.
 
 ## Workflow
 
-1. Complete the local `.env` configuration check.
-2. Inspect the installed package version and public exports.
-3. Use `CodexPluginRegistry` to discover commands and capabilities.
-4. Prefer structured outputs and validators for machine-consumed responses.
-5. Use Responses API helpers for new OpenAI integrations.
-6. Redact keys, authorization headers, tokens, and secret-bearing errors.
-7. Run relevant tests and type checks after generated changes.
-
-## Example
+1. Run `openai-helpers-credentials doctor`.
+2. Load `.env` locally with `python-dotenv`.
+3. Use the package's Codex registry and typed helpers.
+4. Prefer structured outputs and validators.
+5. Redact credentials and authorization headers from outputs and errors.
+6. Run relevant tests and type checks after code changes.
 
 ```python
 from dotenv import load_dotenv
@@ -64,5 +52,3 @@ load_dotenv(".env")
 registry = CodexPluginRegistry()
 print(registry.list_commands())
 ```
-
-Follow the repository's NumPy-style docstring, Pyright, Black, and pytest conventions when editing code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,54 +19,37 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # Template rendering
     "jinja2",
-
-    # Data modeling
     "pydantic>=2.7,<3",
     "typing_extensions>=4.15.0,<5",
-
-    # Environment variable management
     "python-dotenv",
-
-    # OpenAI functionality
-    # Baseline aligned with the July 2026 OpenAI Python SDK generation.
     "openai>=2.45.0,<3.0.0",
     "openai-agents>=0.18.1,<1.0.0",
-
-    # Language extraction
     "langextract",
-
-    # Web UI
     "streamlit",
 ]
 
 [project.optional-dependencies]
 dev = [
-    # Linting and docstring style checks
     "pydocstyle",
     "pyright",
-
-    # Formatting
     "black",
     "black[jupyter]",
-
-    # Testing
     "pytest-cov",
     "pytest",
     "pytest-asyncio",
 ]
-extract = [
-    "langextract",
-]
+extract = ["langextract"]
+
+[project.scripts]
+openai-helpers = "openai_sdk_helpers.cli:main"
+openai-helpers-credentials = "openai_sdk_helpers.credential_cli:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-# Ship the entire package tree so Python modules are included alongside the
-# bundled prompt templates.
 include = ["src/openai_sdk_helpers"]
 
 [tool.hatch.build.targets.wheel]
@@ -83,6 +66,3 @@ convention = "numpy"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-
-[project.scripts]
-openai-helpers = "openai_sdk_helpers.cli:main"

--- a/src/openai_sdk_helpers/credential_cli.py
+++ b/src/openai_sdk_helpers/credential_cli.py
@@ -1,0 +1,124 @@
+"""Local-only credential setup for openai-sdk-helpers."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+from dotenv import dotenv_values
+
+REQUIRED_VARIABLES = ("OPENAI_API_KEY",)
+OPTIONAL_VARIABLES = ("OPENAI_PROJECT", "OPENAI_ORG_ID")
+
+
+def _is_ignored(env_path: Path) -> bool:
+    """Return whether a nearby gitignore explicitly ignores ``.env``."""
+    for parent in (env_path.parent, *env_path.parents):
+        gitignore = parent / ".gitignore"
+        if gitignore.is_file():
+            entries = {
+                line.strip()
+                for line in gitignore.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            }
+            return ".env" in entries or "*.env" in entries
+        if (parent / ".git").exists():
+            break
+    return False
+
+
+def _write_env(path: Path, values: Dict[str, str]) -> None:
+    """Write local credentials with restrictive permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(f"{name}={value}\n" for name, value in values.items() if value),
+        encoding="utf-8",
+    )
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def configure(env_file: Path, *, force: bool = False) -> int:
+    """Interactively create a local OpenAI credential file."""
+    if env_file.exists() and not force:
+        print(f"Refusing to overwrite {env_file}. Use --force to replace it.")
+        return 2
+
+    print("OpenAI SDK Helpers local credential setup")
+    print("Credentials remain in this local .env file and are never uploaded.")
+    values = {
+        "OPENAI_API_KEY": getpass.getpass("OpenAI API key: ").strip(),
+        "OPENAI_PROJECT": input("OpenAI project ID (optional): ").strip(),
+        "OPENAI_ORG_ID": input("OpenAI organization ID (optional): ").strip(),
+    }
+    if not values["OPENAI_API_KEY"]:
+        print("Missing required value: OPENAI_API_KEY")
+        return 2
+
+    _write_env(env_file, values)
+    print(f"Created {env_file} with local-only permissions where supported.")
+    if not _is_ignored(env_file):
+        print("WARNING: add .env to the repository .gitignore before committing.")
+        return 1
+    print("Credential setup complete. Run `openai-helpers-credentials doctor`.")
+    return 0
+
+
+def doctor(env_file: Path) -> int:
+    """Validate local OpenAI credentials without displaying values."""
+    problems = []
+    if not env_file.is_file():
+        problems.append(f"missing credential file: {env_file}")
+        values: Dict[str, Optional[str]] = {}
+    else:
+        values = dict(dotenv_values(env_file))
+        missing = [name for name in REQUIRED_VARIABLES if not values.get(name)]
+        if missing:
+            problems.append("missing variables: " + ", ".join(missing))
+        if os.name != "nt" and env_file.stat().st_mode & 0o077:
+            problems.append("credential file permissions are too broad; run chmod 600 .env")
+    if not _is_ignored(env_file):
+        problems.append(".env is not explicitly ignored by .gitignore")
+
+    if problems:
+        print("OpenAI SDK Helpers credential check failed:")
+        for problem in problems:
+            print(f"- {problem}")
+        print("Run `openai-helpers-credentials configure` to repair it.")
+        return 1
+
+    configured_optional = [name for name in OPTIONAL_VARIABLES if values.get(name)]
+    print("OpenAI SDK Helpers local credential check passed.")
+    print("OPENAI_API_KEY is present; its value was not displayed.")
+    if configured_optional:
+        print("Optional variables present: " + ", ".join(configured_optional))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the credential command parser."""
+    parser = argparse.ArgumentParser(prog="openai-helpers-credentials")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    configure_parser = subparsers.add_parser("configure")
+    configure_parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    configure_parser.add_argument("--force", action="store_true")
+    doctor_parser = subparsers.add_parser("doctor")
+    doctor_parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the local credential command."""
+    args = build_parser().parse_args(argv)
+    if args.command == "configure":
+        return configure(args.env_file, force=args.force)
+    return doctor(args.env_file)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add `openai-helpers-credentials configure`
- add `openai-helpers-credentials doctor`
- securely prompt for the API key without echoing it
- validate required variables, file permissions, and `.gitignore` coverage
- document the first-use flow in the Codex skill

Credentials remain local and are never displayed.