### PR TITLE
feat: add governed self-improving AI-native loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/ai-improvement.yml
@@ -1,0 +1,53 @@
+name: AI improvement
+description: Agent-ready improvement proposal for the self-improving product loop
+title: "[AI improvement] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for a bounded, testable improvement that an agent can implement through a pull request.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is missing, failing, outdated, or unnecessarily difficult?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include CI output, code locations, user feedback, release notes, benchmarks, or documentation gaps.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the observable result and acceptance criteria.
+    validations:
+      required: true
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Governance risk
+      options:
+        - Safe maintenance
+        - Public API change
+        - Breaking change
+        - Security change
+        - Credential change
+        - Release change
+    validations:
+      required: true
+  - type: checkboxes
+    id: agent
+    attributes:
+      label: Agent handoff
+      options:
+        - label: The scope is bounded enough for an agent-created pull request.
+          required: true
+        - label: Tests or validation steps are identified.
+          required: true
+        - label: High-impact changes will receive human approval before merge.
+          required: true

--- a/.github/workflows/ai-self-improvement.yml
+++ b/.github/workflows/ai-self-improvement.yml
@@ -1,0 +1,62 @@
+name: AI self-improvement discovery
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Discover actionable maintenance markers
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          findings="$(grep -RInE 'TODO|FIXME|HACK|XXX' src tests docs scripts 2>/dev/null | head -n 50 || true)"
+          if [ -z "$findings" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          {
+            echo 'findings<<EOF'
+            echo "$findings"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Create one deduplicated agent-ready issue
+        if: steps.scan.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FINDINGS: ${{ steps.scan.outputs.findings }}
+        shell: bash
+        run: |
+          title='[AI improvement] Review discovered maintenance markers'
+          existing="$(gh issue list --state open --search "in:title $title" --json number --jq 'length')"
+          if [ "$existing" != "0" ]; then
+            echo "An open discovery issue already exists."
+            exit 0
+          fi
+          body="$(cat <<EOF
+          ## Problem
+          Automated discovery found maintenance markers that may represent technical debt or incomplete product work.
+
+          ## Evidence
+          \`\`\`
+          $FINDINGS
+          \`\`\`
+
+          ## Desired outcome
+          Triage each finding against PRODUCT.md, ROADMAP.md, and AI_NATIVE_PLATFORM.yaml. Close obsolete markers and turn valid work into bounded, testable changes.
+
+          ## Agent handoff
+          An agent may prepare a pull request after confirming scope. Breaking, security, credential, public API, and release changes require human approval before merge.
+          EOF
+          )"
+          gh issue create --title "$title" --body "$body"

--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -3,6 +3,7 @@ version: 1
 platform:
   name: First Class AI Native Platform
   required: true
+  standard_repository: fatmambot33/ai-native-platform
 
 product:
   name: openai-sdk-helpers
@@ -73,10 +74,42 @@ quality:
   ai_evaluations: true
   benchmark: true
 
+self_improvement:
+  enabled: true
+  github_issues_as_work_queue: true
+  discover_improvements: true
+  create_issues: true
+  agent_ready_issues: true
+  agent_can_open_pull_requests: true
+  run_ci_before_merge: true
+  update_roadmap_and_changelog: true
+  sources:
+    - ci_failures
+    - dependency_updates
+    - release_notes
+    - user_feedback
+    - todos
+    - code_analysis
+    - documentation_gaps
+  governance:
+    human_approval_required:
+      - breaking_changes
+      - security_changes
+      - credential_changes
+      - public_api_changes
+      - release_changes
+    safe_auto_merge:
+      - documentation
+      - tests
+      - formatting
+      - examples
+      - non_breaking_maintenance
+
 release:
   block_if_quality_fails: true
   block_if_doctor_fails: true
   block_if_plugin_invalid: true
+  block_if_self_improvement_contract_invalid: true
   validate_manifest: python scripts/validate_ai_native_platform.py
 
 agent:
@@ -86,3 +119,4 @@ agent:
     - human_confirmation_for_writes
     - deterministic_tool_discovery
     - structured_outputs
+    - issue_driven_self_improvement

--- a/scripts/validate_ai_native_platform.py
+++ b/scripts/validate_ai_native_platform.py
@@ -27,14 +27,23 @@ REQUIRED_TRUE_PATHS = (
     ("quality", "typed"),
     ("quality", "tests"),
     ("quality", "docs"),
+    ("self_improvement", "enabled"),
+    ("self_improvement", "github_issues_as_work_queue"),
+    ("self_improvement", "discover_improvements"),
+    ("self_improvement", "create_issues"),
+    ("self_improvement", "agent_ready_issues"),
+    ("self_improvement", "agent_can_open_pull_requests"),
+    ("self_improvement", "run_ci_before_merge"),
     ("release", "block_if_quality_fails"),
     ("release", "block_if_plugin_invalid"),
+    ("release", "block_if_self_improvement_contract_invalid"),
 )
-REQUIRED_GUARANTEES = {"deterministic_tool_discovery", "structured_outputs"}
+REQUIRED_GUARANTEES = {"deterministic_tool_discovery", "structured_outputs", "issue_driven_self_improvement"}
+REQUIRED_SOURCES = {"ci_failures", "user_feedback", "todos", "code_analysis"}
+REQUIRED_APPROVALS = {"breaking_changes", "security_changes", "credential_changes", "public_api_changes", "release_changes"}
 
 
 def read_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
-    """Read one nested manifest value."""
     current: Any = data
     for key in path:
         if not isinstance(current, dict) or key not in current:
@@ -44,7 +53,6 @@ def read_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
 
 
 def main() -> int:
-    """Validate the canonical manifest and return a process exit code."""
     if not MANIFEST.is_file():
         print(f"Missing required manifest: {MANIFEST}")
         return 1
@@ -59,6 +67,8 @@ def main() -> int:
                 errors.append(f"{'.'.join(path)} must be true")
         except KeyError:
             errors.append(f"missing {'.'.join(path)}")
+    if not data.get("platform", {}).get("standard_repository"):
+        errors.append("platform.standard_repository is required")
     commands = set(data.get("commands", {}).get("required", []))
     for command in ("validate", "test", "docs", "examples", "upgrade", "uninstall"):
         if command not in commands:
@@ -73,10 +83,21 @@ def main() -> int:
         for command in ("configure", "doctor"):
             if command not in commands:
                 errors.append(f"credentialed products require command {command}")
+    improvement = data.get("self_improvement", {})
+    missing_sources = REQUIRED_SOURCES - set(improvement.get("sources", []))
+    if missing_sources:
+        errors.append("missing self-improvement sources: " + ", ".join(sorted(missing_sources)))
+    approvals = set(improvement.get("governance", {}).get("human_approval_required", []))
+    missing_approvals = REQUIRED_APPROVALS - approvals
+    if missing_approvals:
+        errors.append("missing human approval gates: " + ", ".join(sorted(missing_approvals)))
     guarantees = set(data.get("agent", {}).get("guarantees", []))
     missing_guarantees = REQUIRED_GUARANTEES - guarantees
     if missing_guarantees:
         errors.append("missing agent guarantees: " + ", ".join(sorted(missing_guarantees)))
+    for path in (Path(".github/ISSUE_TEMPLATE/ai-improvement.yml"), Path(".github/workflows/ai-self-improvement.yml")):
+        if not path.is_file():
+            errors.append(f"missing required self-improvement file: {path}")
     if errors:
         print("AI-native platform manifest validation failed:")
         for error in errors:


### PR DESCRIPTION
## Summary

- make GitHub Issues the required AI work queue
- add an agent-ready improvement issue form
- add scheduled and manual maintenance discovery
- deduplicate generated discovery issues
- allow agents to prepare PRs while preserving human approval for breaking, security, credential, public API, and release changes
- enforce the self-improvement contract in `AI_NATIVE_PLATFORM.yaml` and CI validation

The manifest points to the intended shared standard repository `fatmambot33/ai-native-platform`, ready to extract once repository creation is available.