### PR TITLE
chore: adopt verified AI-native standard revision

### DIFF
--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -1,7 +1,7 @@
 version: 1
 standard:
   repository: fatmambot33/ai-native-platform
-  ref: 12ea076844deeb9a04b9a549b304d933f84b1c65
+  ref: 67ec7caf19ead3282ea1aad29c43906f59e64d67
 product:
   name: openai-sdk-helpers
   ai_native: true


### PR DESCRIPTION
Updates `AI_NATIVE_PLATFORM.yaml` from `12ea076844deeb9a04b9a549b304d933f84b1c65` to the self-validating canonical revision `67ec7caf19ead3282ea1aad29c43906f59e64d67`.

No product capability, behavior, API, or policy changes.

Closes #129
Tracks fatmambot33/ai-native-platform#2.