### PR TITLE
feat: finish Codex plugin production roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,9 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Completed Codex plugin production hardening.
+- Added optional structured plugin metadata and capability inspection.
+- Added isolated entry-point discovery reports without changing fail-fast discovery.
+- Added `openai-helpers codex plugins` and `openai-helpers codex commands`.
+- Added installed entry-point discovery coverage, compatibility policy, and a 0.8 migration guide.
 - Standardized repository documentation.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Codex plugin hardening
+
+- Added optional `CodexPluginMetadata` with contract version, implementation version, summary, capabilities, and deprecation state.
+- Added deterministic plugin and command inspection through `inspect_plugins()`.
+- Added isolated installed-plugin discovery through `discover_isolated()` with structured failure reports.
+- Added `openai-helpers codex plugins` and `openai-helpers codex commands`.
+- Added compatibility policy and migration guidance for the next minor release.
+
+These additions are backward compatible. Existing plugins that only implement `name` and `setup(context)` continue to work unchanged, and `discover()` retains fail-fast behavior.
+
 ### Breaking Changes (beta)
 
 - `ResponseConfiguration` now performs strict `tools` validation at initialization time.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,18 +14,18 @@ Every roadmap item must support `PRODUCT.md` and preserve a small, typed, predic
 - [x] Add atomic rollback when plugin setup fails.
 - [x] Add a runnable first-plugin example and packaging guide.
 
-## Next — production hardening
+## Completed — production hardening
 
-- [ ] Define plugin compatibility and deprecation policy.
-- [ ] Add isolated discovery failure reporting.
-- [ ] Add structured plugin metadata and capability inspection.
-- [ ] Add CLI commands to list plugins and commands.
-- [ ] Test installed entry-point discovery end to end.
-- [ ] Add migration guidance before the next minor release.
+- [x] Define plugin compatibility and deprecation policy.
+- [x] Add isolated discovery failure reporting.
+- [x] Add structured plugin metadata and capability inspection.
+- [x] Add CLI commands to list plugins and commands.
+- [x] Test installed entry-point discovery end to end.
+- [x] Add migration guidance before the next minor release.
 
-## Later — official integrations
+## Next — official integrations
 
-Official integrations should remain optional and use the same plugin contract:
+Official integrations remain optional and use the same plugin contract. They should be proposed only when a concrete user workflow justifies them:
 
 - Responses
 - Agents

--- a/docs/codex-plugin-migration-0.8.md
+++ b/docs/codex-plugin-migration-0.8.md
@@ -1,0 +1,60 @@
+# Codex plugin migration guide for 0.8
+
+The 0.8 hardening work is backward compatible for existing plugins. A plugin that only defines `name` and `setup(context)` requires no code change.
+
+## Recommended metadata
+
+Add structured metadata so hosts can inspect identity and capabilities without executing commands:
+
+```python
+from openai_sdk_helpers.codex import CodexPluginMetadata
+
+
+class MyPlugin:
+    name = "my-plugin"
+    metadata = CodexPluginMetadata(
+        name=name,
+        version="1.4.0",
+        summary="My reusable Codex workflows.",
+        capabilities=("responses", "file-search"),
+    )
+```
+
+The metadata name must match `plugin.name`. Keep `api_version` at its default unless the plugin intentionally targets a newer contract.
+
+## Safer host discovery
+
+Existing hosts may keep fail-fast discovery:
+
+```python
+registry.discover()
+```
+
+Hosts that load optional or third-party packages should migrate to isolated discovery:
+
+```python
+report = registry.discover_isolated()
+if not report.ok:
+    for failure in report.failures:
+        logger.warning(
+            "Codex plugin %s failed: %s: %s",
+            failure.entry_point,
+            failure.error_type,
+            failure.message,
+        )
+```
+
+Healthy plugins remain registered even when another entry point fails.
+
+## Operational inspection
+
+Use `registry.inspect_plugins()` for deterministic plugin metadata and command ownership. Operators can also use:
+
+```console
+openai-helpers codex plugins
+openai-helpers codex commands
+```
+
+## Deprecation
+
+Set `deprecated=True` in plugin metadata before removal. Document the replacement and keep the deprecated plugin functional for at least one minor release whenever practical.

--- a/docs/codex-plugins.md
+++ b/docs/codex-plugins.md
@@ -1,15 +1,24 @@
 # Codex plugins
 
-`openai-sdk-helpers` provides a deliberately small plugin contract for reusable Codex workflows. The registry handles discovery, command routing, lifecycle hooks, and sync or async execution without hiding OpenAI SDK calls.
+`openai-sdk-helpers` provides a deliberately small plugin contract for reusable Codex workflows. The registry handles discovery, command routing, lifecycle hooks, sync or async execution, and inspection without hiding OpenAI SDK calls.
 
 ## Create a plugin
 
 ```python
-from openai_sdk_helpers import CodexPluginContext
+from openai_sdk_helpers.codex import (
+    CodexPluginContext,
+    CodexPluginMetadata,
+)
 
 
 class MyPlugin:
     name = "my-plugin"
+    metadata = CodexPluginMetadata(
+        name=name,
+        version="1.0.0",
+        summary="Example Codex workflow commands.",
+        capabilities=("responses", "tools"),
+    )
 
     def setup(self, context: CodexPluginContext) -> None:
         context.add_command("hello", lambda name: f"Hello, {name}!")
@@ -23,7 +32,7 @@ class MyPlugin:
         pass
 ```
 
-Only `name` and `setup(context)` are required. `startup()` and `shutdown()` are optional and may be synchronous or asynchronous.
+Only `name` and `setup(context)` are required. Structured `metadata` is optional, so plugins written against the original contract remain valid. `startup()` and `shutdown()` are optional and may be synchronous or asynchronous.
 
 ## Run plugins directly
 
@@ -37,7 +46,19 @@ async with registry:
     result = await registry.run_async("hello", "Codex")
 ```
 
-Use `run()` for synchronous commands. It intentionally returns an awaitable unchanged when the registered command is asynchronous. Use `run_async()` when command type is not known by the caller.
+Use `run()` for synchronous commands. It intentionally returns an awaitable unchanged when the registered command is asynchronous. Use `run_async()` when the command type is not known by the caller.
+
+## Inspect capabilities
+
+```python
+for plugin in registry.inspect_plugins():
+    print(plugin.metadata.name)
+    print(plugin.metadata.version)
+    print(plugin.metadata.capabilities)
+    print(plugin.command_names)
+```
+
+Capability identifiers are plugin-defined, stable strings. They describe what a plugin exposes; they do not grant permissions or trigger network calls.
 
 ## Publish an installable plugin
 
@@ -56,6 +77,42 @@ registry.discover()
 ```
 
 An entry point may expose either a plugin instance or a plugin class with a no-argument constructor.
+
+## Isolate discovery failures
+
+`discover()` keeps its original fail-fast behavior. Production hosts that load third-party plugins should use the isolated API:
+
+```python
+report = registry.discover_isolated()
+
+for failure in report.failures:
+    print(failure.entry_point, failure.error_type, failure.message)
+```
+
+A broken package cannot prevent later entry points from loading. The report contains successful plugins and deterministic failure records.
+
+## CLI inspection
+
+```console
+openai-helpers codex plugins
+openai-helpers codex commands
+```
+
+Both commands use isolated discovery. They return a non-zero exit code when any installed plugin fails to load while still printing healthy plugins and commands.
+
+## Compatibility and deprecation policy
+
+The current plugin contract version is `1`, exposed as `CODEX_PLUGIN_API_VERSION`.
+
+- The required `name` and `setup(context)` protocol remains backward compatible throughout the `0.x` package line unless a security or correctness issue makes that impossible.
+- Optional metadata fields and new inspection methods may be added without changing the plugin API version.
+- A plugin that declares an unsupported `api_version` is rejected before setup, with a clear compatibility error.
+- A planned removal must be documented for at least one minor release before removal.
+- Deprecated plugins should set `CodexPluginMetadata(deprecated=True)` and provide migration guidance in their own documentation.
+- `discover()` remains fail-fast for compatibility. Safer behavior is additive through `discover_isolated()`.
+- Command names and capability identifiers are owned by plugins. Renaming or removing them is a plugin-level breaking change.
+
+See [the 0.8 migration guide](codex-plugin-migration-0.8.md) for adoption guidance.
 
 ## Registration guarantees
 

--- a/src/openai_sdk_helpers/cli.py
+++ b/src/openai_sdk_helpers/cli.py
@@ -1,18 +1,7 @@
 """Command-line interface for openai-sdk-helpers development.
 
-Provides CLI commands for testing agents, validating templates,
-and inspecting the response registry.
-
-Commands
---------
-agent test
-    Test an agent locally with sample inputs.
-template validate
-    Validate Jinja2 templates for syntax errors.
-registry list
-    List all registered response configurations.
-registry inspect
-    Inspect a specific configuration.
+Provides CLI commands for testing agents, validating templates, inspecting
+response configurations, and inspecting installed Codex plugins.
 """
 
 from __future__ import annotations
@@ -28,22 +17,13 @@ def cmd_agent_test(args: argparse.Namespace) -> int:
 
     Parameters
     ----------
-    args : argparse.Namespace
-        Command arguments containing agent_name and input.
+    args
+        Command arguments containing ``agent_name`` and ``input``.
 
     Returns
     -------
     int
-        Exit code (0 for success).
-
-    Raises
-    ------
-    NotImplementedError
-        As the function is not yet implemented.
-
-    Examples
-    --------
-    >>> cmd_agent_test(argparse.Namespace(agent_name="test", input="hello"))
+        Exit code.
     """
     print(f"Testing agent: {args.agent_name}")
     print(f"Input: {args.input}")
@@ -56,37 +36,25 @@ def cmd_template_validate(args: argparse.Namespace) -> int:
 
     Parameters
     ----------
-    args : argparse.Namespace
-        Command arguments containing template_path.
+    args
+        Command arguments containing ``template_path``.
 
     Returns
     -------
     int
-        Exit code (0 for success, 1 for validation errors).
-
-    Raises
-    ------
-    FileNotFoundError
-        If the template path does not exist.
-
-    Examples
-    --------
-    >>> cmd_template_validate(argparse.Namespace(template_path="."))
+        Zero for success and one for validation errors.
     """
     from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
 
     template_path = Path(args.template_path)
-
     if not template_path.exists():
         print(f"Error: Path not found: {template_path}", file=sys.stderr)
         return 1
 
     if template_path.is_file():
-        # Validate single file
         templates = [template_path]
         base_dir = template_path.parent
     else:
-        # Validate directory
         templates = list(template_path.glob("**/*.jinja"))
         base_dir = template_path
 
@@ -96,15 +64,14 @@ def cmd_template_validate(args: argparse.Namespace) -> int:
 
     env = Environment(loader=FileSystemLoader(base_dir))
     errors = []
-
     for template_file in templates:
         relative_path = template_file.relative_to(base_dir)
         try:
             env.get_template(str(relative_path))
             print(f"✓ {relative_path}")
-        except TemplateSyntaxError as e:
-            errors.append((relative_path, str(e)))
-            print(f"✗ {relative_path}: {e}", file=sys.stderr)
+        except TemplateSyntaxError as exc:
+            errors.append((relative_path, str(exc)))
+            print(f"✗ {relative_path}: {exc}", file=sys.stderr)
 
     if errors:
         print(f"\n{len(errors)} template(s) with errors", file=sys.stderr)
@@ -119,23 +86,15 @@ def cmd_registry_list(args: argparse.Namespace) -> int:
 
     Parameters
     ----------
-    args : argparse.Namespace
-        Command arguments.
+    args
+        Parsed command arguments.
 
     Returns
     -------
     int
-        Exit code (0 for success).
-
-    Raises
-    ------
-    ImportError
-        If openai_sdk_helpers is not installed.
-
-    Examples
-    --------
-    >>> cmd_registry_list(argparse.Namespace())
+        Exit code.
     """
+    del args
     try:
         from openai_sdk_helpers import get_default_registry
     except ImportError:
@@ -144,7 +103,6 @@ def cmd_registry_list(args: argparse.Namespace) -> int:
 
     registry = get_default_registry()
     names = registry.list_names()
-
     if not names:
         print("No configurations registered")
         return 0
@@ -154,33 +112,21 @@ def cmd_registry_list(args: argparse.Namespace) -> int:
         configuration = registry.get(name)
         tools_count = len(configuration.tools) if configuration.tools else 0
         print(f"  - {name} ({tools_count} tools)")
-
     return 0
 
 
 def cmd_registry_inspect(args: argparse.Namespace) -> int:
-    """Inspect a specific configuration.
+    """Inspect a specific response configuration.
 
     Parameters
     ----------
-    args : argparse.Namespace
-        Command arguments containing config_name.
+    args
+        Command arguments containing ``config_name``.
 
     Returns
     -------
     int
-        Exit code (0 for success, 1 for not found).
-
-    Raises
-    ------
-    ImportError
-        If openai_sdk_helpers is not installed.
-    KeyError
-        If the configuration is not found in the registry.
-
-    Examples
-    --------
-    >>> cmd_registry_inspect(argparse.Namespace(config_name="my_config"))
+        Zero for success and one when the configuration is absent.
     """
     try:
         from openai_sdk_helpers import get_default_registry
@@ -189,7 +135,6 @@ def cmd_registry_inspect(args: argparse.Namespace) -> int:
         return 1
 
     registry = get_default_registry()
-
     try:
         configuration = registry.get(args.config_name)
     except KeyError:
@@ -206,7 +151,6 @@ def cmd_registry_inspect(args: argparse.Namespace) -> int:
     )
     print(f"Instructions: {instructions_preview}...")
     print(f"Tools: {len(configuration.tools) if configuration.tools else 0}")
-
     if configuration.tools:
         print("\nTool names:")
         for tool in configuration.tools:
@@ -218,8 +162,90 @@ def cmd_registry_inspect(args: argparse.Namespace) -> int:
                     if isinstance(name_value, str) and name_value:
                         tool_name = name_value
             print(f"  - {tool_name}")
-
     return 0
+
+
+def cmd_codex_plugins(args: argparse.Namespace) -> int:
+    """Discover and list installed Codex plugins.
+
+    Parameters
+    ----------
+    args
+        Parsed command arguments.
+
+    Returns
+    -------
+    int
+        Zero when discovery succeeds and one when any plugin fails to load.
+    """
+    del args
+    from openai_sdk_helpers.codex import CodexPluginRegistry
+
+    registry = CodexPluginRegistry()
+    report = registry.discover_isolated()
+    inspections = registry.inspect_plugins()
+    if not inspections:
+        print("No Codex plugins discovered")
+    else:
+        print("Codex plugins:")
+        for inspection in inspections:
+            metadata = inspection.metadata
+            capabilities = ", ".join(metadata.capabilities) or "none"
+            deprecated = " [deprecated]" if metadata.deprecated else ""
+            print(f"  - {metadata.name} {metadata.version}{deprecated}")
+            print(f"    capabilities: {capabilities}")
+            if metadata.summary:
+                print(f"    {metadata.summary}")
+
+    _print_codex_discovery_failures(report.failures)
+    return 0 if report.ok else 1
+
+
+def cmd_codex_commands(args: argparse.Namespace) -> int:
+    """Discover installed Codex plugins and list their commands.
+
+    Parameters
+    ----------
+    args
+        Parsed command arguments.
+
+    Returns
+    -------
+    int
+        Zero when discovery succeeds and one when any plugin fails to load.
+    """
+    del args
+    from openai_sdk_helpers.codex import CodexPluginRegistry
+
+    registry = CodexPluginRegistry()
+    report = registry.discover_isolated()
+    inspections = registry.inspect_plugins()
+    commands_found = False
+    for inspection in inspections:
+        for command_name in inspection.command_names:
+            if not commands_found:
+                print("Codex commands:")
+                commands_found = True
+            print(f"  - {command_name} ({inspection.metadata.name})")
+    if not commands_found:
+        print("No Codex commands discovered")
+
+    _print_codex_discovery_failures(report.failures)
+    return 0 if report.ok else 1
+
+
+def _print_codex_discovery_failures(failures: tuple[object, ...]) -> None:
+    if not failures:
+        return
+    print("Codex plugin discovery failures:", file=sys.stderr)
+    for failure in failures:
+        entry_point = getattr(failure, "entry_point", "unknown")
+        error_type = getattr(failure, "error_type", "Error")
+        message = getattr(failure, "message", "")
+        print(
+            f"  - {entry_point}: {error_type}: {message}",
+            file=sys.stderr,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -227,70 +253,64 @@ def main(argv: list[str] | None = None) -> int:
 
     Parameters
     ----------
-    argv : list[str], optional
-        Command-line arguments. If None, uses sys.argv.
+    argv
+        Command-line arguments. Uses ``sys.argv`` when omitted.
 
     Returns
     -------
     int
         Exit code.
-
-    Examples
-    --------
-    >>> main(["agent", "test", "my_agent"])
     """
     parser = argparse.ArgumentParser(
         prog="openai-helpers",
         description="OpenAI SDK Helpers CLI",
     )
-
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 
-    # Agent test command
     agent_parser = subparsers.add_parser("agent", help="Agent operations")
     agent_sub = agent_parser.add_subparsers(dest="agent_command")
-
     test_parser = agent_sub.add_parser("test", help="Test an agent")
     test_parser.add_argument("agent_name", help="Agent name to test")
     test_parser.add_argument("--input", default="", help="Test input")
 
-    # Template validate command
     template_parser = subparsers.add_parser("template", help="Template operations")
     template_sub = template_parser.add_subparsers(dest="template_command")
-
     validate_parser = template_sub.add_parser("validate", help="Validate templates")
     validate_parser.add_argument(
         "template_path",
         help="Path to template file or directory",
     )
 
-    # Registry commands
     registry_parser = subparsers.add_parser("registry", help="Registry operations")
     registry_sub = registry_parser.add_subparsers(dest="registry_command")
-
     registry_sub.add_parser("list", help="List registered configurations")
-
     inspect_parser = registry_sub.add_parser("inspect", help="Inspect configuration")
     inspect_parser.add_argument("config_name", help="Configuration name")
 
-    args = parser.parse_args(argv)
+    codex_parser = subparsers.add_parser("codex", help="Codex plugin operations")
+    codex_sub = codex_parser.add_subparsers(dest="codex_command")
+    codex_sub.add_parser("plugins", help="List installed Codex plugins")
+    codex_sub.add_parser("commands", help="List installed Codex commands")
 
+    args = parser.parse_args(argv)
     if not args.command:
         parser.print_help()
         return 0
 
-    # Route commands
-    if args.command == "agent":
-        if args.agent_command == "test":
-            return cmd_agent_test(args)
-    elif args.command == "template":
-        if args.template_command == "validate":
-            return cmd_template_validate(args)
-    elif args.command == "registry":
+    if args.command == "agent" and args.agent_command == "test":
+        return cmd_agent_test(args)
+    if args.command == "template" and args.template_command == "validate":
+        return cmd_template_validate(args)
+    if args.command == "registry":
         if args.registry_command == "list":
             return cmd_registry_list(args)
-        elif args.registry_command == "inspect":
+        if args.registry_command == "inspect":
             return cmd_registry_inspect(args)
+    if args.command == "codex":
+        if args.codex_command == "plugins":
+            return cmd_codex_plugins(args)
+        if args.codex_command == "commands":
+            return cmd_codex_commands(args)
 
     parser.print_help()
     return 0

--- a/src/openai_sdk_helpers/codex/__init__.py
+++ b/src/openai_sdk_helpers/codex/__init__.py
@@ -1,12 +1,29 @@
 """First-class, lightweight Codex plugin surface."""
 
-from .plugin import CodexCommand, CodexPlugin, CodexPluginContext
-from .registry import CODEX_PLUGIN_ENTRY_POINT, CodexPluginRegistry
+from .plugin import (
+    CODEX_PLUGIN_API_VERSION,
+    CodexCommand,
+    CodexPlugin,
+    CodexPluginContext,
+    CodexPluginMetadata,
+)
+from .registry import (
+    CODEX_PLUGIN_ENTRY_POINT,
+    CodexPluginDiscoveryFailure,
+    CodexPluginDiscoveryReport,
+    CodexPluginInspection,
+    CodexPluginRegistry,
+)
 
 __all__ = [
+    "CODEX_PLUGIN_API_VERSION",
     "CODEX_PLUGIN_ENTRY_POINT",
     "CodexCommand",
     "CodexPlugin",
     "CodexPluginContext",
+    "CodexPluginDiscoveryFailure",
+    "CodexPluginDiscoveryReport",
+    "CodexPluginInspection",
+    "CodexPluginMetadata",
     "CodexPluginRegistry",
 ]

--- a/src/openai_sdk_helpers/codex/plugin.py
+++ b/src/openai_sdk_helpers/codex/plugin.py
@@ -5,7 +5,62 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping, Protocol, runtime_checkable
 
+CODEX_PLUGIN_API_VERSION = "1"
 CodexCommand = Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class CodexPluginMetadata:
+    """Structured identity and capabilities for a Codex plugin.
+
+    Parameters
+    ----------
+    name
+        Stable plugin name. It must match the plugin's ``name`` attribute.
+    version
+        Plugin package or implementation version.
+    summary
+        Short human-readable description.
+    capabilities
+        Stable capability identifiers exposed by the plugin.
+    api_version
+        Codex plugin contract version implemented by the plugin.
+    deprecated
+        Whether users should migrate away from the plugin.
+    """
+
+    name: str
+    version: str = "0"
+    summary: str = ""
+    capabilities: tuple[str, ...] = ()
+    api_version: str = CODEX_PLUGIN_API_VERSION
+    deprecated: bool = False
+
+    def __post_init__(self) -> None:
+        """Normalize values and reject ambiguous metadata."""
+        name = self.name.strip()
+        version = self.version.strip()
+        api_version = self.api_version.strip()
+        if not name:
+            raise ValueError("Plugin metadata name must not be empty.")
+        if not version:
+            raise ValueError("Plugin metadata version must not be empty.")
+        if not api_version:
+            raise ValueError("Plugin API version must not be empty.")
+
+        capabilities: list[str] = []
+        for capability in self.capabilities:
+            normalized = capability.strip()
+            if not normalized:
+                raise ValueError("Plugin capabilities must not be empty.")
+            if normalized not in capabilities:
+                capabilities.append(normalized)
+
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "version", version)
+        object.__setattr__(self, "summary", self.summary.strip())
+        object.__setattr__(self, "api_version", api_version)
+        object.__setattr__(self, "capabilities", tuple(capabilities))
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/openai_sdk_helpers/codex/registry.py
+++ b/src/openai_sdk_helpers/codex/registry.py
@@ -3,12 +3,50 @@
 from __future__ import annotations
 
 import inspect
+from dataclasses import dataclass
 from importlib.metadata import EntryPoint, entry_points
 from typing import Any, Iterable, Mapping
 
-from .plugin import CodexCommand, CodexPlugin, CodexPluginContext
+from .plugin import (
+    CODEX_PLUGIN_API_VERSION,
+    CodexCommand,
+    CodexPlugin,
+    CodexPluginContext,
+    CodexPluginMetadata,
+)
 
 CODEX_PLUGIN_ENTRY_POINT = "openai_sdk_helpers.codex"
+
+
+@dataclass(frozen=True, slots=True)
+class CodexPluginInspection:
+    """Inspectable plugin metadata and registered commands."""
+
+    metadata: CodexPluginMetadata
+    command_names: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CodexPluginDiscoveryFailure:
+    """Serializable failure captured while loading one entry point."""
+
+    entry_point: str
+    value: str
+    error_type: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class CodexPluginDiscoveryReport:
+    """Successful plugins and isolated discovery failures."""
+
+    plugins: tuple[CodexPlugin, ...]
+    failures: tuple[CodexPluginDiscoveryFailure, ...]
+
+    @property
+    def ok(self) -> bool:
+        """Return whether every entry point loaded successfully."""
+        return not self.failures
 
 
 class CodexPluginRegistry:
@@ -22,6 +60,8 @@ class CodexPluginRegistry:
 
     def __init__(self, *, metadata: Mapping[str, Any] | None = None) -> None:
         self._plugins: dict[str, CodexPlugin] = {}
+        self._plugin_metadata: dict[str, CodexPluginMetadata] = {}
+        self._plugin_commands: dict[str, tuple[str, ...]] = {}
         self._commands: dict[str, CodexCommand] = {}
         self._context = CodexPluginContext(
             commands=self._commands,
@@ -62,7 +102,7 @@ class CodexPluginRegistry:
         TypeError
             If the object does not implement the plugin protocol.
         ValueError
-            If its name is empty or already registered.
+            If its name is empty, duplicated, or incompatible.
         RuntimeError
             If registration is attempted after startup.
         """
@@ -76,6 +116,7 @@ class CodexPluginRegistry:
         if name in self._plugins:
             raise ValueError(f"Plugin already registered: {name}")
 
+        metadata = self._resolve_metadata(plugin, name)
         previous_commands = dict(self._commands)
         try:
             plugin.setup(self._context)
@@ -84,12 +125,33 @@ class CodexPluginRegistry:
             self._commands.update(previous_commands)
             raise
 
+        command_names = tuple(
+            command_name
+            for command_name in self._commands
+            if command_name not in previous_commands
+        )
         self._plugins[name] = plugin
+        self._plugin_metadata[name] = metadata
+        self._plugin_commands[name] = command_names
         return plugin
 
     def get_plugin(self, name: str) -> CodexPlugin:
         """Return a registered plugin by name."""
         return self._plugins[name]
+
+    def get_plugin_metadata(self, name: str) -> CodexPluginMetadata:
+        """Return normalized metadata for a registered plugin."""
+        return self._plugin_metadata[name]
+
+    def inspect_plugins(self) -> tuple[CodexPluginInspection, ...]:
+        """Return deterministic metadata and command capability inspection."""
+        return tuple(
+            CodexPluginInspection(
+                metadata=self._plugin_metadata[name],
+                command_names=self._plugin_commands[name],
+            )
+            for name in self._plugins
+        )
 
     def run(self, command: str, /, *args: Any, **kwargs: Any) -> Any:
         """Execute a registered command.
@@ -139,24 +201,68 @@ class CodexPluginRegistry:
     def discover(
         self, group: str = CODEX_PLUGIN_ENTRY_POINT
     ) -> tuple[CodexPlugin, ...]:
-        """Load and register plugins exposed through package entry points."""
+        """Load and register plugins, preserving fail-fast compatibility."""
         discovered = entry_points().select(group=group)
         return self.load_entry_points(discovered)
+
+    def discover_isolated(
+        self, group: str = CODEX_PLUGIN_ENTRY_POINT
+    ) -> CodexPluginDiscoveryReport:
+        """Load installed plugins while isolating each entry-point failure."""
+        discovered = entry_points().select(group=group)
+        return self.load_entry_points_isolated(discovered)
 
     def load_entry_points(
         self, entry_point_values: Iterable[EntryPoint]
     ) -> tuple[CodexPlugin, ...]:
-        """Load plugins from explicit entry points.
-
-        This separate method keeps discovery easy to test without installed
-        distributions.
-        """
+        """Load plugins from explicit entry points using fail-fast behavior."""
         loaded: list[CodexPlugin] = []
         for entry_point in entry_point_values:
-            candidate = entry_point.load()
-            plugin = candidate() if isinstance(candidate, type) else candidate
-            loaded.append(self.register(plugin))
+            loaded.append(self._load_entry_point(entry_point))
         return tuple(loaded)
+
+    def load_entry_points_isolated(
+        self, entry_point_values: Iterable[EntryPoint]
+    ) -> CodexPluginDiscoveryReport:
+        """Load explicit entry points and report failures independently."""
+        loaded: list[CodexPlugin] = []
+        failures: list[CodexPluginDiscoveryFailure] = []
+        for entry_point in entry_point_values:
+            try:
+                loaded.append(self._load_entry_point(entry_point))
+            except Exception as exc:
+                failures.append(
+                    CodexPluginDiscoveryFailure(
+                        entry_point=entry_point.name,
+                        value=entry_point.value,
+                        error_type=type(exc).__name__,
+                        message=str(exc),
+                    )
+                )
+        return CodexPluginDiscoveryReport(tuple(loaded), tuple(failures))
+
+    def _load_entry_point(self, entry_point: EntryPoint) -> CodexPlugin:
+        candidate = entry_point.load()
+        plugin = candidate() if isinstance(candidate, type) else candidate
+        return self.register(plugin)
+
+    @staticmethod
+    def _resolve_metadata(
+        plugin: CodexPlugin, name: str
+    ) -> CodexPluginMetadata:
+        raw_metadata = getattr(plugin, "metadata", None)
+        if raw_metadata is None:
+            return CodexPluginMetadata(name=name)
+        if not isinstance(raw_metadata, CodexPluginMetadata):
+            raise TypeError("Plugin metadata must be CodexPluginMetadata.")
+        if raw_metadata.name != name:
+            raise ValueError("Plugin metadata name must match plugin name.")
+        if raw_metadata.api_version != CODEX_PLUGIN_API_VERSION:
+            raise ValueError(
+                "Unsupported Codex plugin API version: "
+                f"{raw_metadata.api_version}; expected {CODEX_PLUGIN_API_VERSION}."
+            )
+        return raw_metadata
 
     @staticmethod
     async def _call_hook(plugin: CodexPlugin, hook_name: str) -> None:

--- a/src/openai_sdk_helpers/codex/registry.py
+++ b/src/openai_sdk_helpers/codex/registry.py
@@ -247,9 +247,7 @@ class CodexPluginRegistry:
         return self.register(plugin)
 
     @staticmethod
-    def _resolve_metadata(
-        plugin: CodexPlugin, name: str
-    ) -> CodexPluginMetadata:
+    def _resolve_metadata(plugin: CodexPlugin, name: str) -> CodexPluginMetadata:
         raw_metadata = getattr(plugin, "metadata", None)
         if raw_metadata is None:
             return CodexPluginMetadata(name=name)

--- a/tests/test_codex_hardening.py
+++ b/tests/test_codex_hardening.py
@@ -1,0 +1,144 @@
+"""Production-hardening tests for the Codex plugin surface."""
+
+from __future__ import annotations
+
+import importlib
+from importlib.metadata import EntryPoint
+
+import pytest
+
+from openai_sdk_helpers.cli import main
+from openai_sdk_helpers.codex import (
+    CodexPluginContext,
+    CodexPluginMetadata,
+    CodexPluginRegistry,
+)
+
+
+class MetadataPlugin:
+    """Plugin with structured metadata for inspection tests."""
+
+    name = "metadata"
+    metadata = CodexPluginMetadata(
+        name="metadata",
+        version="1.2.3",
+        summary="Metadata test plugin.",
+        capabilities=("responses", "tools", "tools"),
+    )
+
+    def setup(self, context: CodexPluginContext) -> None:
+        """Register one command."""
+        context.add_command("metadata.hello", lambda: "hello")
+
+
+def test_metadata_and_capability_inspection() -> None:
+    registry = CodexPluginRegistry()
+    registry.register(MetadataPlugin())
+
+    inspection = registry.inspect_plugins()[0]
+
+    assert inspection.metadata.version == "1.2.3"
+    assert inspection.metadata.capabilities == ("responses", "tools")
+    assert inspection.command_names == ("metadata.hello",)
+
+
+def test_plugin_without_metadata_remains_supported() -> None:
+    class LegacyPlugin:
+        name = "legacy"
+
+        def setup(self, context: CodexPluginContext) -> None:
+            context.add_command("legacy.run", lambda: None)
+
+    registry = CodexPluginRegistry()
+    registry.register(LegacyPlugin())
+
+    metadata = registry.get_plugin_metadata("legacy")
+    assert metadata.name == "legacy"
+    assert metadata.version == "0"
+
+
+def test_incompatible_plugin_api_version_is_rejected() -> None:
+    class IncompatiblePlugin:
+        name = "incompatible"
+        metadata = CodexPluginMetadata(name=name, api_version="2")
+
+        def setup(self, context: CodexPluginContext) -> None:
+            context.add_command("incompatible.run", lambda: None)
+
+    with pytest.raises(ValueError, match="Unsupported Codex plugin API version"):
+        CodexPluginRegistry().register(IncompatiblePlugin())
+
+
+def test_isolated_discovery_reports_failure_and_keeps_success() -> None:
+    registry = CodexPluginRegistry()
+    good = EntryPoint(
+        name="metadata",
+        value=f"{__name__}:MetadataPlugin",
+        group="test.codex",
+    )
+    bad = EntryPoint(
+        name="broken",
+        value="missing_codex_plugin:Plugin",
+        group="test.codex",
+    )
+
+    report = registry.load_entry_points_isolated((bad, good))
+
+    assert registry.plugin_names == ("metadata",)
+    assert len(report.plugins) == 1
+    assert report.failures[0].entry_point == "broken"
+    assert report.failures[0].error_type == "ModuleNotFoundError"
+    assert report.ok is False
+
+
+def test_installed_entry_point_discovery_end_to_end(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = tmp_path / "installed_codex_plugin.py"
+    module.write_text(
+        "from openai_sdk_helpers.codex import CodexPluginContext\n"
+        "class InstalledPlugin:\n"
+        "    name = 'installed'\n"
+        "    def setup(self, context: CodexPluginContext) -> None:\n"
+        "        context.add_command('installed.run', lambda: 'installed')\n",
+        encoding="utf-8",
+    )
+    dist_info = tmp_path / "installed_codex_plugin-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: installed-codex-plugin\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    group = "openai_sdk_helpers.codex.test"
+    (dist_info / "entry_points.txt").write_text(
+        f"[{group}]\ninstalled = installed_codex_plugin:InstalledPlugin\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+
+    registry = CodexPluginRegistry()
+    plugins = registry.discover(group=group)
+
+    assert plugins[0].name == "installed"
+    assert registry.run("installed.run") == "installed"
+
+
+def test_codex_cli_lists_plugins_and_commands(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def discover(self: CodexPluginRegistry, group: str = ""):
+        del group
+        self.register(MetadataPlugin())
+        return self.load_entry_points_isolated(())
+
+    monkeypatch.setattr(CodexPluginRegistry, "discover_isolated", discover)
+
+    assert main(["codex", "plugins"]) == 0
+    plugin_output = capsys.readouterr().out
+    assert "metadata 1.2.3" in plugin_output
+    assert "responses, tools" in plugin_output
+
+    assert main(["codex", "commands"]) == 0
+    command_output = capsys.readouterr().out
+    assert "metadata.hello (metadata)" in command_output


### PR DESCRIPTION
## What changed

- add optional structured Codex plugin metadata and capability inspection
- add explicit plugin contract version validation and deprecation state
- add isolated entry-point discovery reports while preserving fail-fast `discover()`
- add `openai-helpers codex plugins` and `openai-helpers codex commands`
- add installed `.dist-info` entry-point discovery coverage
- define compatibility and deprecation policy, add the 0.8 migration guide, and close the production-hardening roadmap

## Why

The Codex plugin foundation was functional but still lacked production diagnostics, compatibility governance, operator inspection, and end-to-end package discovery validation. This completes those roadmap gates without hiding OpenAI API calls or making optional integrations mandatory.

## Compatibility

Existing plugins that only implement `name` and `setup(context)` remain supported. `discover()` keeps fail-fast behavior; isolated discovery is additive through `discover_isolated()`.

## Validation

- focused smoke and pytest suite: 6 passed
- Python compilation passed for the changed modules
- full repository lint, type, test, coverage, package, and compatibility checks run in GitHub Actions
