### PR TITLE
Make optional integrations truly optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint-and-type:
     name: Lint and Type Check
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +32,7 @@ jobs:
         run: pydocstyle src
 
       - name: Format check with black
-        run: black --check .
+        run: black --check --diff .
 
       - name: Type check with pyright
         run: pyright src

--- a/.github/workflows/optional-dependencies.yml
+++ b/.github/workflows/optional-dependencies.yml
@@ -1,0 +1,45 @@
+name: Optional dependency installs
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  install-profile:
+    name: Install ${{ matrix.profile }} profile
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: core
+            target: "."
+          - profile: extract
+            target: ".[extract]"
+          - profile: ui
+            target: ".[ui]"
+          - profile: all
+            target: ".[all]"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install package profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "${{ matrix.target }}"
+          python -m pip check
+
+      - name: Validate package profile
+        run: python scripts/validate_optional_install.py "${{ matrix.profile }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Made LangExtract and Streamlit optional through the `extract`, `ui`, and `all` installation profiles.
+- Added lazy extraction exports with actionable missing-extra errors and clean-install CI coverage.
 - Completed Codex plugin production hardening.
 - Added optional structured plugin metadata and capability inspection.
 - Added isolated entry-point discovery reports without changing fail-fast discovery.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,60 @@
+# Installation profiles
+
+`openai-sdk-helpers` keeps optional integrations out of the base installation.
+Install only the capabilities used by the application.
+
+## Core
+
+```bash
+pip install openai-sdk-helpers
+```
+
+The core profile includes the OpenAI Python SDK, the OpenAI Agents SDK,
+Pydantic, Jinja, settings helpers, Responses helpers, Agents helpers, vector
+storage, tools, validation, and the Codex plugin surface. It does not install
+LangExtract or Streamlit.
+
+## Document extraction
+
+```bash
+pip install "openai-sdk-helpers[extract]"
+```
+
+The `extract` profile installs LangExtract and enables:
+
+- `DocumentExtractor`
+- `ExtractorAgent`
+- extraction structures such as `DocumentStructure`
+- extraction prompt generation and optimization helpers
+
+Existing package-root imports remain supported. Accessing an extraction export
+without the extra raises an `ImportError` containing the installation command.
+
+## Streamlit UI
+
+```bash
+pip install "openai-sdk-helpers[ui]"
+```
+
+The `ui` profile installs Streamlit and enables the configuration-driven
+`openai_sdk_helpers.streamlit_app` surface.
+
+## All optional capabilities
+
+```bash
+pip install "openai-sdk-helpers[all]"
+```
+
+Use this profile for environments that need both document extraction and the
+Streamlit UI.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+```
+
+The development profile includes test, formatting, type-checking, extraction,
+and UI dependencies so the complete repository test suite can run locally.
+Clean-install CI separately validates `core`, `extract`, `ui`, and `all` to
+prevent optional dependencies from leaking back into the base package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ dependencies = [
     "python-dotenv",
     "openai>=2.45.0,<3.0.0",
     "openai-agents>=0.18.1,<1.0.0",
-    "langextract",
-    "streamlit",
 ]
 
 [project.optional-dependencies]
@@ -38,8 +36,15 @@ dev = [
     "pytest-cov",
     "pytest",
     "pytest-asyncio",
+    "langextract",
+    "streamlit",
 ]
 extract = ["langextract"]
+ui = ["streamlit"]
+all = [
+    "langextract",
+    "streamlit",
+]
 
 [project.scripts]
 openai-helpers = "openai_sdk_helpers.cli:main"

--- a/scripts/validate_optional_install.py
+++ b/scripts/validate_optional_install.py
@@ -1,0 +1,98 @@
+"""Validate clean installation profiles for optional package capabilities."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from typing import Sequence
+
+
+def _require_missing(module_name: str) -> None:
+    """Assert that a module is absent from the current environment.
+
+    Parameters
+    ----------
+    module_name : str
+        Top-level module expected to be unavailable.
+    """
+    if importlib.util.find_spec(module_name) is not None:
+        raise AssertionError(f"{module_name!r} must not be installed in core profile")
+
+
+def _validate_core() -> None:
+    """Validate the dependency-minimal base installation."""
+    import openai_sdk_helpers
+    import openai_sdk_helpers.agent
+    import openai_sdk_helpers.structure
+
+    _require_missing("langextract")
+    _require_missing("streamlit")
+
+    for name in ("DocumentExtractor", "ExtractorAgent", "DocumentStructure"):
+        try:
+            getattr(openai_sdk_helpers, name)
+        except ImportError as exc:
+            expected = 'pip install "openai-sdk-helpers[extract]"'
+            if expected not in str(exc):
+                raise AssertionError(
+                    f"Missing-extra error for {name} did not include {expected!r}"
+                ) from exc
+        else:
+            raise AssertionError(f"{name} unexpectedly loaded without extract extra")
+
+
+def _validate_extract() -> None:
+    """Validate the document extraction installation profile."""
+    import langextract  # noqa: F401
+    from openai_sdk_helpers import DocumentExtractor, DocumentStructure, ExtractorAgent
+    from openai_sdk_helpers.extract import generate_document_extractor_config
+
+    assert DocumentExtractor is not None
+    assert DocumentStructure is not None
+    assert ExtractorAgent is not None
+    assert callable(generate_document_extractor_config)
+
+
+def _validate_ui() -> None:
+    """Validate the Streamlit UI installation profile."""
+    import streamlit  # noqa: F401
+    from openai_sdk_helpers.streamlit_app import (
+        StreamlitAppConfig,
+        StreamlitAppRegistry,
+    )
+
+    assert StreamlitAppConfig is not None
+    assert StreamlitAppRegistry is not None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run validation for one installation profile.
+
+    Parameters
+    ----------
+    argv : Sequence[str] or None, optional
+        Command-line arguments. Uses ``sys.argv`` when omitted.
+
+    Returns
+    -------
+    int
+        Zero when the selected installation profile is valid.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("profile", choices=("core", "extract", "ui", "all"))
+    args = parser.parse_args(argv)
+
+    if args.profile == "core":
+        _validate_core()
+    elif args.profile == "extract":
+        _validate_extract()
+    elif args.profile == "ui":
+        _validate_ui()
+    else:
+        _validate_extract()
+        _validate_ui()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/openai_sdk_helpers/__init__.py
+++ b/src/openai_sdk_helpers/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from importlib.util import find_spec
 from typing import Any
 
 from .codex import (
@@ -179,18 +180,14 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = [
-    # Codex plugins
     "CODEX_PLUGIN_ENTRY_POINT",
     "CodexCommand",
     "CodexPlugin",
     "CodexPluginContext",
     "CodexPluginRegistry",
-    # Environment utilities
     "get_data_path",
-    # Async utilities
     "run_coroutine_thread_safe",
     "run_coroutine_with_fallback",
-    # Error classes
     "OpenAISDKError",
     "ConfigurationError",
     "PromptNotFoundError",
@@ -202,7 +199,6 @@ __all__ = [
     "AsyncExecutionError",
     "ResourceCleanupError",
     "ExtractionError",
-    # Validation
     "validate_non_empty_string",
     "validate_max_length",
     "validate_url_format",
@@ -210,7 +206,6 @@ __all__ = [
     "validate_list_items",
     "validate_choice",
     "validate_safe_path",
-    # Main structure classes
     "StructureBase",
     "SchemaOptions",
     "spec_field",
@@ -270,7 +265,6 @@ __all__ = [
     "create_plan",
     "execute_task",
     "execute_plan",
-    # Output validation
     "ValidationResult",
     "ValidationRule",
     "JSONSchemaValidator",
@@ -278,10 +272,8 @@ __all__ = [
     "LengthValidator",
     "OutputValidator",
     "validate_output",
-    # LangExtract adapter
     "LangExtractAdapter",
     "build_langextract_adapter",
-    # Extraction helpers
     "DocumentExtractor",
     "EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS",
     "EXTRACTOR_CONFIG_GENERATOR",
@@ -291,3 +283,6 @@ __all__ = [
     "optimize_extractor_prompt",
     "optimize_extractor_prompt_with_agent",
 ]
+
+if find_spec("langextract") is None:
+    __all__ = [name for name in __all__ if name not in _OPTIONAL_EXPORTS]

--- a/src/openai_sdk_helpers/__init__.py
+++ b/src/openai_sdk_helpers/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any
+
 from .codex import (
     CODEX_PLUGIN_ENTRY_POINT,
     CodexCommand,
@@ -48,11 +51,6 @@ from .structure import (
     ExtendedSummaryStructure,
     ValidationResultStructure,
     AgentBlueprint,
-    AnnotatedDocumentStructure,
-    AttributeStructure,
-    DocumentStructure,
-    ExampleDataStructure,
-    ExtractionStructure,
     create_plan,
     execute_task,
     execute_plan,
@@ -66,7 +64,6 @@ from .agent import (
     AgentConfiguration,
     AgentEnum,
     CoordinatorAgent,
-    ExtractorAgent,
     SummarizerAgent,
     TranslatorAgent,
     ValidatorAgent,
@@ -109,16 +106,77 @@ from .utils.output_validation import (
     validate_output,
 )
 from .utils.langextract import LangExtractAdapter, build_langextract_adapter
-from .extract import (
-    DocumentExtractor,
-    EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS,
-    EXTRACTOR_CONFIG_GENERATOR,
-    PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS,
-    generate_document_extractor_config,
-    generate_document_extractor_config_with_agent,
-    optimize_extractor_prompt,
-    optimize_extractor_prompt_with_agent,
-)
+
+_OPTIONAL_EXPORTS = {
+    "ExtractorAgent": ("openai_sdk_helpers.agent", "ExtractorAgent"),
+    "AnnotatedDocumentStructure": (
+        "openai_sdk_helpers.structure",
+        "AnnotatedDocumentStructure",
+    ),
+    "AttributeStructure": ("openai_sdk_helpers.structure", "AttributeStructure"),
+    "DocumentStructure": ("openai_sdk_helpers.structure", "DocumentStructure"),
+    "ExampleDataStructure": ("openai_sdk_helpers.structure", "ExampleDataStructure"),
+    "ExtractionStructure": ("openai_sdk_helpers.structure", "ExtractionStructure"),
+    "DocumentExtractor": ("openai_sdk_helpers.extract", "DocumentExtractor"),
+    "EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS": (
+        "openai_sdk_helpers.extract",
+        "EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS",
+    ),
+    "EXTRACTOR_CONFIG_GENERATOR": (
+        "openai_sdk_helpers.extract",
+        "EXTRACTOR_CONFIG_GENERATOR",
+    ),
+    "PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS": (
+        "openai_sdk_helpers.extract",
+        "PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS",
+    ),
+    "generate_document_extractor_config": (
+        "openai_sdk_helpers.extract",
+        "generate_document_extractor_config",
+    ),
+    "generate_document_extractor_config_with_agent": (
+        "openai_sdk_helpers.extract",
+        "generate_document_extractor_config_with_agent",
+    ),
+    "optimize_extractor_prompt": (
+        "openai_sdk_helpers.extract",
+        "optimize_extractor_prompt",
+    ),
+    "optimize_extractor_prompt_with_agent": (
+        "openai_sdk_helpers.extract",
+        "optimize_extractor_prompt_with_agent",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load optional extraction exports only when requested.
+
+    Parameters
+    ----------
+    name : str
+        Requested package attribute.
+
+    Returns
+    -------
+    Any
+        Lazily imported public export.
+
+    Raises
+    ------
+    AttributeError
+        If the requested attribute is not a public optional export.
+    ImportError
+        If the extraction extra is required but not installed.
+    """
+    target = _OPTIONAL_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attribute_name = target
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     # Codex plugins
@@ -220,7 +278,7 @@ __all__ = [
     "LengthValidator",
     "OutputValidator",
     "validate_output",
-    # LangExtract
+    # LangExtract adapter
     "LangExtractAdapter",
     "build_langextract_adapter",
     # Extraction helpers

--- a/src/openai_sdk_helpers/_optional.py
+++ b/src/openai_sdk_helpers/_optional.py
@@ -73,7 +73,7 @@ def optional_dependency_error(
     """
     return ImportError(
         f"{feature} requires the optional dependency '{dependency}'. "
-        f"Install it with: pip install \"openai-sdk-helpers[{extra}]\""
+        f'Install it with: pip install "openai-sdk-helpers[{extra}]"'
     )
 
 

--- a/src/openai_sdk_helpers/_optional.py
+++ b/src/openai_sdk_helpers/_optional.py
@@ -40,9 +40,7 @@ def import_optional_module(
         return import_module(module_name)
     except ModuleNotFoundError as exc:
         missing_name = exc.name or ""
-        if missing_name == dependency or missing_name.startswith(
-            f"{dependency}."
-        ):
+        if missing_name == dependency or missing_name.startswith(f"{dependency}."):
             raise optional_dependency_error(
                 dependency=dependency,
                 extra=extra,

--- a/src/openai_sdk_helpers/_optional.py
+++ b/src/openai_sdk_helpers/_optional.py
@@ -1,0 +1,80 @@
+"""Helpers for optional dependency boundaries."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+
+def import_optional_module(
+    module_name: str,
+    *,
+    dependency: str,
+    extra: str,
+    feature: str,
+) -> ModuleType:
+    """Import an optional module with an actionable installation error.
+
+    Parameters
+    ----------
+    module_name : str
+        Fully qualified module name to import.
+    dependency : str
+        Distribution or top-level import name that provides the module.
+    extra : str
+        Package extra that installs the optional dependency.
+    feature : str
+        Human-readable capability name used in the error message.
+
+    Returns
+    -------
+    ModuleType
+        Imported module.
+
+    Raises
+    ------
+    ImportError
+        If the optional dependency is unavailable.
+    """
+    try:
+        return import_module(module_name)
+    except ModuleNotFoundError as exc:
+        missing_name = exc.name or ""
+        if missing_name == dependency or missing_name.startswith(f"{dependency}."):
+            raise optional_dependency_error(
+                dependency=dependency,
+                extra=extra,
+                feature=feature,
+            ) from exc
+        raise
+
+
+def optional_dependency_error(
+    *,
+    dependency: str,
+    extra: str,
+    feature: str,
+) -> ImportError:
+    """Build an actionable missing optional dependency error.
+
+    Parameters
+    ----------
+    dependency : str
+        Missing dependency name.
+    extra : str
+        Package extra that installs the dependency.
+    feature : str
+        Human-readable capability name.
+
+    Returns
+    -------
+    ImportError
+        Error containing the exact installation command.
+    """
+    return ImportError(
+        f"{feature} requires the optional dependency '{dependency}'. "
+        f"Install it with: pip install \"openai-sdk-helpers[{extra}]\""
+    )
+
+
+__all__ = ["import_optional_module", "optional_dependency_error"]

--- a/src/openai_sdk_helpers/_optional.py
+++ b/src/openai_sdk_helpers/_optional.py
@@ -40,7 +40,9 @@ def import_optional_module(
         return import_module(module_name)
     except ModuleNotFoundError as exc:
         missing_name = exc.name or ""
-        if missing_name == dependency or missing_name.startswith(f"{dependency}."):
+        if missing_name == dependency or missing_name.startswith(
+            f"{dependency}."
+        ):
             raise optional_dependency_error(
                 dependency=dependency,
                 extra=extra,

--- a/src/openai_sdk_helpers/agent/__init__.py
+++ b/src/openai_sdk_helpers/agent/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.util import find_spec
 from typing import Any
 
 from .._optional import import_optional_module
@@ -76,3 +77,6 @@ __all__ = [
     "WebAgentSearch",
     "build_agent_input_messages",
 ]
+
+if find_spec("langextract") is None:
+    __all__.remove("ExtractorAgent")

--- a/src/openai_sdk_helpers/agent/__init__.py
+++ b/src/openai_sdk_helpers/agent/__init__.py
@@ -1,21 +1,58 @@
 """Shared agent helpers built on the OpenAI Agents SDK."""
 
 from __future__ import annotations
-from .base import AgentBase
-from .configuration import AgentConfiguration, AgentRegistry, get_default_registry
+
+from typing import Any
+
+from .._optional import import_optional_module
 from ..structure.plan.enum import AgentEnum
-from .coordinator import CoordinatorAgent
-from .runner import run_sync, run_async
-from .search.base import SearchPlanner, SearchToolAgent, SearchWriter
+from .base import AgentBase
 from .classifier import TaxonomyClassifierAgent
-from .summarizer import SummarizerAgent
-from .translator import TranslatorAgent
-from .validator import ValidatorAgent
-from .extractor import ExtractorAgent
-from .utils import run_coroutine_agent_sync
+from .configuration import AgentConfiguration, AgentRegistry, get_default_registry
+from .coordinator import CoordinatorAgent
+from .files import build_agent_input_messages
+from .runner import run_async, run_sync
+from .search.base import SearchPlanner, SearchToolAgent, SearchWriter
 from .search.vector import VectorAgentSearch
 from .search.web import WebAgentSearch
-from .files import build_agent_input_messages
+from .summarizer import SummarizerAgent
+from .translator import TranslatorAgent
+from .utils import run_coroutine_agent_sync
+from .validator import ValidatorAgent
+
+
+def __getattr__(name: str) -> Any:
+    """Load optional agent integrations only when requested.
+
+    Parameters
+    ----------
+    name : str
+        Requested module attribute.
+
+    Returns
+    -------
+    Any
+        Lazily imported optional agent class.
+
+    Raises
+    ------
+    AttributeError
+        If the requested name is not an optional public export.
+    ImportError
+        If the required optional dependency is not installed.
+    """
+    if name != "ExtractorAgent":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_optional_module(
+        "openai_sdk_helpers.agent.extractor",
+        dependency="langextract",
+        extra="extract",
+        feature="ExtractorAgent",
+    )
+    value = module.ExtractorAgent
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "AgentBase",

--- a/src/openai_sdk_helpers/extract/__init__.py
+++ b/src/openai_sdk_helpers/extract/__init__.py
@@ -1,14 +1,39 @@
 """LangExtract-powered document extraction helpers."""
 
-from .extractor import DocumentExtractor
-from .generator import (
-    EXTRACTOR_CONFIG_GENERATOR,
-    EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS,
-    PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS,
-    generate_document_extractor_config,
-    generate_document_extractor_config_with_agent,
-    optimize_extractor_prompt,
-    optimize_extractor_prompt_with_agent,
+from __future__ import annotations
+
+from .._optional import import_optional_module
+
+_extractor_module = import_optional_module(
+    "openai_sdk_helpers.extract.extractor",
+    dependency="langextract",
+    extra="extract",
+    feature="Document extraction",
+)
+_generator_module = import_optional_module(
+    "openai_sdk_helpers.extract.generator",
+    dependency="langextract",
+    extra="extract",
+    feature="Document extraction",
+)
+
+DocumentExtractor = _extractor_module.DocumentExtractor
+EXTRACTOR_CONFIG_GENERATOR = _generator_module.EXTRACTOR_CONFIG_GENERATOR
+EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS = (
+    _generator_module.EXTRACTOR_CONFIG_AGENT_INSTRUCTIONS
+)
+PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS = (
+    _generator_module.PROMPT_OPTIMIZER_AGENT_INSTRUCTIONS
+)
+generate_document_extractor_config = (
+    _generator_module.generate_document_extractor_config
+)
+generate_document_extractor_config_with_agent = (
+    _generator_module.generate_document_extractor_config_with_agent
+)
+optimize_extractor_prompt = _generator_module.optimize_extractor_prompt
+optimize_extractor_prompt_with_agent = (
+    _generator_module.optimize_extractor_prompt_with_agent
 )
 
 __all__ = [

--- a/src/openai_sdk_helpers/structure/__init__.py
+++ b/src/openai_sdk_helpers/structure/__init__.py
@@ -8,6 +8,7 @@ generating OpenAI-compatible schema definitions.
 
 from __future__ import annotations
 
+from importlib.util import find_spec
 from typing import Any
 
 from .._optional import import_optional_module
@@ -122,3 +123,6 @@ __all__ = [
     "response_tool_definition",
     "response_format",
 ]
+
+if find_spec("langextract") is None:
+    __all__ = [name for name in __all__ if name not in _EXTRACTION_EXPORTS]

--- a/src/openai_sdk_helpers/structure/__init__.py
+++ b/src/openai_sdk_helpers/structure/__init__.py
@@ -4,76 +4,13 @@ This module provides Pydantic-based structured output models for defining
 schemas, validation, and serialization of AI agent outputs. It includes base
 classes, specialized structures for various agent types, and utilities for
 generating OpenAI-compatible schema definitions.
-
-Classes
--------
-StructureBase
-    Base class for all structured output models with schema generation.
-SchemaOptions
-    Configuration options for schema generation behavior.
-AgentBlueprint
-    Structure for designing and planning new agents.
-AgentEnum
-    Enumeration of available agent types.
-TaskStructure
-    Representation of a single task in an execution plan.
-PlanStructure
-    Ordered sequence of tasks for multi-step agent workflows.
-PromptStructure
-    Structure for prompt design and validation.
-SummaryTopic
-    Individual topic within a summary.
-SummaryStructure
-    Basic summary with topic breakdown.
-ExtendedSummaryStructure
-    Enhanced summary with additional metadata.
-TranslationStructure
-    Structured translation output.
-WebSearchStructure
-    Web search results structure.
-WebSearchPlanStructure
-    Planned web search queries and strategy.
-WebSearchItemStructure
-    Individual web search item.
-WebSearchItemResultStructure
-    Result from executing a web search item.
-WebSearchReportStructure
-    Complete web search report with findings.
-VectorSearchStructure
-    Vector database search results.
-VectorSearchPlanStructure
-    Planned vector search queries.
-VectorSearchItemStructure
-    Individual vector search query.
-VectorSearchItemResultStructure
-    Result from executing a vector search query.
-VectorSearchItemResultsStructure
-    Collection of vector search results.
-VectorSearchReportStructure
-    Complete vector search report.
-ValidationResultStructure
-    Validation results with pass/fail status.
-ExtractionItem
-    Extracted item with source span data.
-ExtractionResult
-    Structured extraction results for a document.
-
-Functions
----------
-spec_field
-    Create a Pydantic Field with standard documentation formatting.
-assistant_tool_definition
-    Build function tool definition for Assistant APIs.
-assistant_format
-    Build response format for Assistant APIs.
-response_tool_definition
-    Build function tool definition for chat completions.
-response_format
-    Build response format for chat completions.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+from .._optional import import_optional_module
 from .agent_blueprint import AgentBlueprint
 from .base import *
 from .classification import (
@@ -87,13 +24,6 @@ from .classification import (
     split_path_identifier,
     taxonomy_enum_path,
 )
-from .extraction import (
-    AnnotatedDocumentStructure,
-    AttributeStructure,
-    DocumentStructure,
-    ExampleDataStructure,
-    ExtractionStructure,
-)
 from .plan import *
 from .prompt import PromptStructure
 from .responses import *
@@ -102,6 +32,48 @@ from .translation import TranslationStructure
 from .validation import ValidationResultStructure
 from .vector_search import *
 from .web_search import *
+
+_EXTRACTION_EXPORTS = {
+    "AnnotatedDocumentStructure",
+    "AttributeStructure",
+    "DocumentStructure",
+    "ExampleDataStructure",
+    "ExtractionStructure",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load extraction structures only when the extraction extra is used.
+
+    Parameters
+    ----------
+    name : str
+        Requested module attribute.
+
+    Returns
+    -------
+    Any
+        Lazily imported extraction structure.
+
+    Raises
+    ------
+    AttributeError
+        If the requested name is not a public extraction structure.
+    ImportError
+        If ``openai-sdk-helpers[extract]`` is not installed.
+    """
+    if name not in _EXTRACTION_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_optional_module(
+        "openai_sdk_helpers.structure.extraction",
+        dependency="langextract",
+        extra="extract",
+        feature="Document extraction",
+    )
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "StructureBase",

--- a/src/openai_sdk_helpers/utils/langextract.py
+++ b/src/openai_sdk_helpers/utils/langextract.py
@@ -11,6 +11,8 @@ from typing import Any, Protocol, TypeVar
 
 from pydantic import BaseModel
 
+from .._optional import import_optional_module
+
 TModel = TypeVar("TModel", bound=BaseModel)
 
 
@@ -158,7 +160,7 @@ def build_langextract_adapter(
     Raises
     ------
     ImportError
-        If LangExtract cannot be imported.
+        If ``openai-sdk-helpers[extract]`` is not installed.
     AttributeError
         If no supported extractor can be resolved.
     """
@@ -177,7 +179,7 @@ def build_langextract_adapter(
 
 
 def _import_langextract_module() -> Any:
-    """Import the LangExtract module.
+    """Import the optional LangExtract module.
 
     Returns
     -------
@@ -187,8 +189,11 @@ def _import_langextract_module() -> Any:
     Raises
     ------
     ImportError
-        If LangExtract is not installed or cannot be imported.
+        If ``openai-sdk-helpers[extract]`` is not installed.
     """
-    import importlib
-
-    return importlib.import_module("langextract")
+    return import_optional_module(
+        "langextract",
+        dependency="langextract",
+        extra="extract",
+        feature="LangExtract integration",
+    )


### PR DESCRIPTION
## What changed

- remove LangExtract and Streamlit from the base dependency set
- add `extract`, `ui`, and `all` installation profiles
- lazy-load extraction exports from the package root, `agent`, and `structure`
- preserve existing imports when the extraction extra is installed
- provide actionable missing-extra errors
- add clean-install CI for core and every optional profile
- document installation profiles and update the changelog

## Why

The base distribution installed UI and extraction dependencies for every user and eagerly imported LangExtract-backed modules. This contradicted the project’s thin, composable product contract and prevented a genuinely minimal core installation.

## Developer impact

Existing extraction imports continue to work with `openai-sdk-helpers[extract]`. Streamlit users should install `openai-sdk-helpers[ui]`. Development installs continue to include all dependencies through `.[dev]`.

## Validation

GitHub Actions validates formatting, docstrings, typing, the full test matrix, and isolated `core`, `extract`, `ui`, and `all` installations.

Closes #132