### PR TITLE
Make PyPI publishing OIDC-only

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,6 +1,6 @@
 # Publishes each package version once and creates matching release evidence.
-# Set PYPI_TRUSTED_PUBLISHING=true as a repository variable after registering
-# this workflow and the `pypi` environment as a Trusted Publisher on PyPI.
+# Configure this workflow and the `pypi` environment as a Trusted Publisher
+# on PyPI before approving a production publication.
 name: Release Python package
 
 on:
@@ -11,6 +11,12 @@ on:
       - CHANGELOG.md
       - .github/workflows/python-publish.yml
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish to PyPI and reconcile the GitHub release
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: release-python-package
@@ -133,7 +139,11 @@ jobs:
 
   publish:
     needs: [check, build]
-    if: needs.check.outputs.published != 'true'
+    if: >-
+      ${{
+        needs.check.outputs.published != 'true' &&
+        (github.event_name != 'workflow_dispatch' || inputs.publish)
+      }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -144,17 +154,17 @@ jobs:
           name: python-package-distributions
           path: dist
       - name: Publish through PyPI Trusted Publishing
-        if: ${{ vars.PYPI_TRUSTED_PUBLISHING == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Publish with migration token
-        if: ${{ vars.PYPI_TRUSTED_PUBLISHING != 'true' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   release:
     needs: [check, build, publish]
-    if: ${{ always() && needs.build.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
+    if: >-
+      ${{
+        always() &&
+        needs.build.result == 'success' &&
+        (needs.check.outputs.published == 'true' || needs.publish.result == 'success') &&
+        (github.event_name != 'workflow_dispatch' || inputs.publish)
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Removed the legacy PyPI API-token publishing fallback in favor of OIDC-only Trusted Publishing.
+- Added a non-publishing release rehearsal mode and documented publisher setup, verification, and recovery.
 - Made LangExtract and Streamlit optional through the `extract`, `ui`, and `all` installation profiles.
 - Added lazy extraction exports with actionable missing-extra errors and clean-install CI coverage.
 - Completed Codex plugin production hardening.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,115 @@
+# Publishing
+
+`openai-sdk-helpers` publishes through PyPI Trusted Publishing. The release
+workflow never accepts a PyPI username, password, or long-lived API token.
+
+## Trust configuration
+
+Configure the existing PyPI project with this GitHub Actions publisher:
+
+| Field | Value |
+| --- | --- |
+| PyPI project | `openai-sdk-helpers` |
+| GitHub owner | `fatmambot33` |
+| GitHub repository | `openai-sdk-helpers` |
+| Workflow filename | `python-publish.yml` |
+| GitHub environment | `pypi` |
+
+On PyPI, open the project management page, select **Publishing**, add a GitHub
+Actions Trusted Publisher, and enter the values above. The filename is the
+basename under `.github/workflows`, not the complete path.
+
+On GitHub, create the `pypi` environment and protect it with required reviewers.
+Restrict deployment branches to `main`. The environment does not need a PyPI
+secret: the publish job receives only `id-token: write`, exchanges its GitHub
+OIDC identity for a short-lived PyPI credential, and uploads the validated
+artifacts.
+
+After one successful Trusted Publishing release, remove any legacy
+`PYPI_API_TOKEN` repository or environment secret. The workflow does not read
+that secret and intentionally has no token fallback.
+
+## Release flow
+
+A production publication is built once and reused throughout the workflow:
+
+1. Resolve the package version and check whether it already exists on PyPI.
+2. Build the wheel and source distribution in an isolated job.
+3. Validate metadata with Twine.
+4. Install and import the exact wheel in a clean virtual environment.
+5. Generate a reproducible CycloneDX SBOM.
+6. Create GitHub artifact attestations for the distributions.
+7. Pass the artifacts to the minimal `pypi` environment job.
+8. Publish through `pypa/gh-action-pypi-publish` using OIDC.
+9. Create or reconcile the matching `v<version>` GitHub release from the same
+   commit and artifacts.
+
+The PyPA publish action also uploads PyPI publish attestations by default when
+Trusted Publishing is used.
+
+## Rehearsal without publishing
+
+Run **Release Python package** manually and leave **Publish to PyPI and reconcile
+the GitHub release** disabled. The workflow performs version resolution, package
+build, metadata validation, clean-wheel installation, SBOM generation, artifact
+attestation, and artifact upload. It skips both PyPI publication and GitHub
+release creation.
+
+Download the `python-package-distributions` and `release-evidence` workflow
+artifacts to inspect the exact release candidates. This is the supported dry-run
+path and does not require a TestPyPI project or credential.
+
+For a local equivalent:
+
+```bash
+python -m pip install --upgrade build twine
+python -m build
+python -m twine check dist/*
+python -m venv .venv-release-check
+.venv-release-check/bin/python -m pip install dist/*.whl
+.venv-release-check/bin/openai-helpers --help
+```
+
+## Production release
+
+1. Merge a version and changelog update into `main` after all repository checks
+   pass.
+2. Review the triggered release workflow.
+3. Approve the `pypi` environment deployment.
+4. Confirm the publish job succeeds.
+5. Verify the PyPI project shows the expected version and attestations.
+6. Verify the matching GitHub release contains the same distributions and SBOM.
+7. Install the released version from PyPI in a clean environment and run the CLI
+   smoke checks.
+
+A manual workflow run can also publish when the `publish` input is explicitly
+enabled and the `pypi` environment deployment is approved.
+
+## Recovery
+
+Trusted Publishing failures should not be bypassed with a token.
+
+- For `invalid-publisher`, compare the PyPI publisher owner, repository,
+  workflow filename, and environment with the table above.
+- If the repository, workflow, or environment is renamed, update the PyPI
+  publisher before retrying.
+- If a release version already exists on PyPI, do not overwrite it. Correct the
+  source, increment the version, and publish a new immutable release.
+- If PyPI publication succeeds but GitHub release reconciliation fails, rerun
+  the workflow. The release job detects the existing immutable PyPI version and
+  reconciles the matching tag and release without uploading the package again.
+- If the Trusted Publisher must be replaced, register the new publisher first,
+  validate it with a new release, and then remove the obsolete publisher.
+
+## Human-owned controls
+
+The following actions require a repository or PyPI owner:
+
+- registering or changing the PyPI Trusted Publisher
+- creating and protecting the GitHub `pypi` environment
+- approving a production deployment
+- removing the legacy PyPI API token
+- changing publisher identity fields
+
+Repository automation may prepare and validate release artifacts, but it must
+not weaken these controls or publish without explicit environment approval.


### PR DESCRIPTION
## What changed

- remove the `PYPI_API_TOKEN` fallback from the production publish job
- make PyPI Trusted Publishing the only authentication path
- add a safe manual rehearsal mode that builds, validates, installs, attests, and uploads artifacts without publishing
- keep the OIDC-enabled publish job minimal: download artifacts, then publish
- prevent dry runs from creating GitHub releases
- document exact PyPI publisher identity, GitHub environment controls, release verification, and recovery
- update the changelog

## Why

A long-lived token fallback weakens the supply-chain boundary and makes it possible to bypass the intended Trusted Publisher identity. The release path should fail closed when OIDC is not configured rather than silently falling back to a repository secret.

## Validation

The repository CI and compatibility suites validate the workflow change alongside the package. A manual workflow dispatch with `publish` disabled is the supported end-to-end release rehearsal.

## Human-owned completion

Issue #133 should close after an owner verifies:

1. the PyPI project trusts `fatmambot33/openai-sdk-helpers`, workflow `python-publish.yml`, environment `pypi`;
2. the GitHub `pypi` environment exists with required reviewers and a `main` deployment restriction;
3. any legacy `PYPI_API_TOKEN` secret is removed after the first successful OIDC release.

Repository implementation for #133.