### PR TITLE
Add a canonical capability matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run docstring style checks
         run: pydocstyle src
 
+      - name: Validate internal Markdown links
+        run: python scripts/check_markdown_links.py
+
       - name: Format check with black
         run: black --check --diff .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Added a canonical capability matrix covering maturity, installation, execution, and SDK escape hatches.
+- Replaced the duplicated README feature inventory with concise canonical documentation navigation.
+- Added deterministic internal Markdown file and anchor validation to CI.
 - Removed the legacy PyPI API-token publishing fallback in favor of OIDC-only Trusted Publishing.
 - Added a non-publishing release rehearsal mode and documented publisher setup, verification, and recovery.
 - Made LangExtract and Streamlit optional through the `extract`, `ui`, and `all` installation profiles.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,73 @@
 # Contributing
 
-1. Open or select an issue.
-2. Keep the change focused.
-3. Add or update tests.
-4. Add type hints and documentation.
-5. Run the project checks.
-6. Open a pull request with a clear summary.
+## Workflow
 
-Before merging, confirm the change supports `PRODUCT.md` and update `CHANGELOG.md` when appropriate.
+1. Open or select one focused issue.
+2. Branch from the current `main` branch.
+3. Keep the implementation small enough for one coherent pull request.
+4. Add or update deterministic tests.
+5. Add type hints and NumPy-style docstrings.
+6. Update the applicable canonical documentation.
+7. Run all repository checks.
+8. Open a pull request with scope, compatibility impact, validation, and issue links.
+
+Before merging, confirm the change supports [PRODUCT.md](PRODUCT.md), preserves a
+usable core installation, and does not hide OpenAI API calls or resource
+ownership behind surprising defaults.
+
+## Required checks
+
+```bash
+pydocstyle src
+black --check --diff .
+pyright src
+pytest -q --cov=src --cov-report=term-missing --cov-fail-under=70
+python scripts/check_markdown_links.py
+```
+
+CI additionally validates supported Python versions, minimum/latest compatible
+OpenAI SDK dependencies, built distributions, installed package profiles, and
+repository governance.
+
+## Documentation ownership
+
+A public change must update every applicable canonical document:
+
+- [docs/capabilities.md](docs/capabilities.md) for capability, maturity,
+  installation, execution, or escape-hatch changes;
+- [docs/public-api.md](docs/public-api.md) for intentional import changes;
+- [docs/installation.md](docs/installation.md) for dependency profiles;
+- the focused behavior guide for semantics and examples;
+- [CHANGELOG.md](CHANGELOG.md) for user-visible changes;
+- [README.md](README.md) only when top-level navigation or the product summary changes.
+
+Do not copy the capability matrix into the README or repeat long guides across
+multiple files. Link to the canonical source instead. Internal Markdown links
+must pass the repository link checker.
+
+## Public API changes
+
+Public additions require:
+
+- an issue that explains the concrete user workflow;
+- a typed, documented contract;
+- sync/async semantics where applicable;
+- explicit ownership and cleanup behavior;
+- access to underlying official SDK objects;
+- compatibility and migration notes;
+- deterministic success and failure tests.
+
+Breaking changes, deprecations, security-sensitive defaults, releases, and new
+public contracts require human review even when implementation is automated.
+
+## Pull-request completion
+
+A pull request is ready to merge only when:
+
+- all required checks pass on the final head commit;
+- no unresolved review thread remains;
+- documentation and changelog entries match the implementation;
+- optional integrations remain outside the base installation;
+- no credential, paid API call, or external network dependency is required by
+  pull-request tests;
+- the linked issue's acceptance criteria are genuinely satisfied.

--- a/README.md
+++ b/README.md
@@ -4,809 +4,194 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/openai-sdk-helpers.svg)](https://pypi.org/project/openai-sdk-helpers/)
 [![Python versions](https://img.shields.io/pypi/pyversions/openai-sdk-helpers.svg)](https://pypi.org/project/openai-sdk-helpers/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Shared primitives for composing OpenAI workflows: high-level agent abstractions
-(via `openai-agents` SDK) and low-level response handling (via `openai` SDK),
-plus structures, prompt rendering, and reusable utilities.
+Small, typed, SDK-first primitives for composing OpenAI Responses, Agents,
+files, vector stores, tools, and Codex plugins.
 
-[Installation](#installation) •
-[Quickstart](#quickstart) •
-[Features](#features) •
-[Documentation](#key-modules) •
-[Contributing](#contributing)
+[Install](#installation) · [Choose a surface](#choose-a-surface) ·
+[Capabilities](docs/capabilities.md) · [Public API](docs/public-api.md) ·
+[Roadmap](ROADMAP.md)
 
 </div>
 
-## Table of Contents
+## Product contract
 
-- [Overview](#overview)
-- [Features](#features)
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Quickstart](#quickstart)
-  - [Text utilities](#text-utilities)
-  - [Centralized OpenAI configuration](#centralized-openai-configuration)
-- [Advanced Usage](#advanced-usage)
-- [Development](#development)
-- [Project Structure](#project-structure)
-- [Key modules](#key-modules)
-- [Contributing](#contributing)
-- [License](#license)
-- [Troubleshooting](#troubleshooting)
+`openai-sdk-helpers` complements the official `openai` and `openai-agents`
+Python packages. It provides reusable production primitives without replacing
+the SDKs, hiding API calls, owning application prompts, or becoming a universal
+agent framework.
 
-## Overview
+Every public helper should be:
 
-`openai-sdk-helpers` packages the common building blocks required to assemble agent-driven
-applications. The library intentionally focuses on reusable primitives—data
-structures, configuration helpers, and orchestration utilities—while leaving
-application-specific prompts and tools to the consuming project.
+- typed and predictable;
+- thin enough that official SDK concepts remain recognizable;
+- explicit about network calls, resource ownership, and cleanup;
+- usable without unrelated optional integrations;
+- tested without requiring paid API calls in pull-request CI;
+- backward-compatible or accompanied by deliberate migration guidance.
 
-**Important**: This library integrates with **two distinct OpenAI SDKs**:
-- **`openai-agents`** - Used by the `agent` module for high-level agent workflows with automatic tool handling
-- **`openai`** - Used by the `response` module for direct API interactions with fine-grained control over responses
-
-The `agent` module provides a higher-level abstraction for building agents, while the `response` module offers lower-level control for custom response handling workflows.
-
-### Key Features
-
-#### Agent Module (Built on `openai-agents` SDK)
-- **Agent wrappers** with synchronous and asynchronous entry points
-- **Prompt rendering** powered by Jinja2 for dynamic agent instructions
-- **Vector and web search flows** that coordinate planning, execution, and
-  reporting with built-in concurrency control
-- **Reusable text agents** for common tasks:
-  - **SummarizerAgent**: Generate concise summaries from provided text
-  - **TranslatorAgent**: Translate text into target languages
-  - **ValidatorAgent**: Check inputs and outputs against safety guardrails
-  - **TaxonomyClassifierAgent**: Classify text into taxonomy-driven labels
-
-#### Response Module (Built on `openai` SDK)
-- **Response handling utilities** for direct API control with fine-grained message management
-- **Tool execution framework** with custom handlers and structured outputs
-- **Session persistence** for saving and restoring conversation history
-
-#### Infrastructure & Utilities
-- **Centralized logger factory** for consistent application logging
-- **Retry patterns** with exponential backoff and jitter
-- **Output validation** framework with JSON schema, semantic, and length validators
-- **CLI tool** for testing agents, validating templates, and inspecting registries
-- **Deprecation utilities** for managing API changes
-
-#### Shared Components
-- **Typed structures** using Pydantic for prompts, responses, and search workflows 
-  to ensure predictable inputs and outputs
-- **OpenAI configuration management** with environment variable and `.env` file support
-- **Vector storage abstraction** for seamless integration with OpenAI vector stores
-- **Type-safe interfaces** with full type hints and `py.typed` marker for external projects
-  - **ValidatorAgent**: Check inputs and outputs against safety guardrails
-
-#### Response Module (Built on `openai` SDK)
-- **Response handling utilities** for direct API control with fine-grained message management
-- **Tool execution framework** with custom handlers and structured outputs
-- **Session persistence** for saving and restoring conversation history
-
-#### Shared Components
-- **Typed structures** using Pydantic for prompts, responses, and search workflows 
-  to ensure predictable inputs and outputs
-- **OpenAI configuration management** with environment variable and `.env` file support
-- **Vector storage abstraction** for seamless integration with OpenAI vector stores
-- **Type-safe interfaces** with full type hints and `py.typed` marker for external projects
-
-## Requirements
-
-- Python 3.10 or higher
-- OpenAI API key (set via `OPENAI_API_KEY` environment variable)
-
-**Note**: This package depends on both:
-- `openai` - The standard OpenAI Python SDK
-- `openai-agents` - The OpenAI Agents SDK for high-level agent workflows
-
-Both are automatically installed when you install `openai-sdk-helpers`.
+See [PRODUCT.md](PRODUCT.md) for the full product vision and feature acceptance
+test.
 
 ## Installation
 
-Install the package directly from PyPI:
+The core package installs both official OpenAI Python SDKs and no UI or
+LangExtract dependency:
 
 ```bash
 pip install openai-sdk-helpers
 ```
 
-The package ships with type information via `py.typed`, enabling full type checking
-support in your IDE and with tools like mypy and pyright.
-
-### Development Installation
-
-For local development with editable sources and optional dev dependencies:
+Optional profiles:
 
 ```bash
-# Clone the repository
-git clone https://github.com/fatmambot33/openai-sdk-helpers.git
-cd openai-sdk-helpers
-
-# Install in editable mode with dev dependencies
-pip install -e .[dev]
+pip install "openai-sdk-helpers[extract]"  # LangExtract-backed extraction
+pip install "openai-sdk-helpers[ui]"       # Streamlit application helpers
+pip install "openai-sdk-helpers[all]"      # All current optional capabilities
 ```
 
-The dev dependencies include:
-- `pydocstyle` - Docstring style checking
-- `pyright` - Static type checking
-- `black` - Code formatting
-- `pytest` and `pytest-cov` - Testing and coverage
+Python 3.10–3.13 is validated in CI. The distribution includes `py.typed`.
+See [docs/installation.md](docs/installation.md) for profile details and
+missing-extra behavior.
 
-## Quickstart
+## Choose a surface
 
-### Basic Vector Search
+### Responses
 
-Create a vector search workflow by wiring your own prompt templates and
-preferred model configuration. This example uses the `agent` module built on `openai-agents` SDK:
-
-```python
-from pathlib import Path
-from openai_sdk_helpers.agent.search.vector import VectorSearch
-
-# Point to your custom prompt directory
-prompts = Path("./prompts")
-
-# Create and configure the vector search agent
-vector_search = VectorSearch(
-    prompt_dir=prompts,
-    default_model="gpt-4o-mini"
-)
-
-# Run a synchronous search query
-report = vector_search.run_agent_sync("Explain quantum entanglement for beginners")
-print(report.report)
-```
-
-**Note**: The vector search workflow ships with default prompt templates
-(`vector_planner.jinja`, `vector_search.jinja`, and `vector_writer.jinja`).
-You only need to pass a `prompt_dir` when you want to override them; if the
-directory you supply is missing any of the templates, agent construction will
-fail with a `FileNotFoundError`.
-
-### Text utilities
-
-The built-in text helpers provide lightweight single-step agents for common tasks.
-These use the `agent` module built on `openai-agents` SDK:
-
-```python
-from openai_sdk_helpers.agent import (
-    SummarizerAgent,
-    TaxonomyClassifierAgent,
-    TranslatorAgent,
-    ValidatorAgent,
-)
-from openai_sdk_helpers.structure import TaxonomyNode
-
-# Initialize agents with a default model
-summarizer = SummarizerAgent(default_model="gpt-4o-mini")
-classifier = TaxonomyClassifierAgent(
-    model="gpt-4o-mini",
-    taxonomy=[TaxonomyNode(label="Billing"), TaxonomyNode(label="Support")],
-)
-translator = TranslatorAgent(default_model="gpt-4o-mini")
-validator = ValidatorAgent(default_model="gpt-4o-mini")
-
-# Generate a summary
-summary = summarizer.run_sync("Long-form content to condense...")
-print(summary.text)
-
-# Translate text
-translation = translator.run_sync("Bonjour", target_language="English")
-print(translation)
-
-# Classify text against a taxonomy
-classification = classifier.run_sync("I need help with my invoice")
-print(classification.final_node)
-
-# Equivalent Responses API classification (no app-side parsing glue)
-from openai_sdk_helpers.response import classify_taxonomy_response
-
-response_classification = classify_taxonomy_response(
-    content="I need help with my invoice",
-    taxonomy=[TaxonomyNode(label="Billing"), TaxonomyNode(label="Support")],
-    model="gpt-4o-mini",
-    return_summary=True,
-)
-print(response_classification.full_paths)
-
-# Validate against guardrails
-validation = validator.run_sync(
-    "Share meeting notes with names removed",
-    agent_output=summary.text
-)
-print(validation.is_safe)
-```
-
-**Important**: These text helpers ship with default prompt templates under
-`src/openai_sdk_helpers/prompt`, so you do **not** need to create placeholder
-files when installing from PyPI. Only pass a `prompt_dir` when you have custom
-templates you want to use instead.
-
-### Centralized OpenAI configuration
-
-`OpenAISettings` provides a centralized way to manage OpenAI SDK configuration
-across your application:
+Use `openai_sdk_helpers.response` when the application needs direct control of
+Responses API inputs, response identifiers, message history, custom tool
+handlers, files, or raw streaming events.
 
 ```python
 from openai_sdk_helpers import OpenAISettings
-
-# Load from environment variables or a local .env file
-settings = OpenAISettings.from_env()
-
-# Create an OpenAI client with loaded settings
-client = settings.create_client()
-
-# Reuse the default model across agents
-from openai_sdk_helpers.agent.search.vector import VectorSearch
-
-vector_search = VectorSearch(
-    prompt_dir=prompts,
-    default_model=settings.default_model or "gpt-4o-mini"
-)
-```
-
-**Supported Environment Variables:**
-- `OPENAI_API_KEY` (required) - Your OpenAI API key
-- `OPENAI_ORG_ID` - Organization identifier
-- `OPENAI_PROJECT_ID` - Project identifier for billing
-- `OPENAI_BASE_URL` - Custom base URL for self-hosted deployments
-- `OPENAI_MODEL` - Default model name
-- `OPENAI_TIMEOUT` - Request timeout in seconds
-- `OPENAI_MAX_RETRIES` - Maximum retry attempts
-
-Pass uncommon OpenAI client keyword arguments (such as `default_headers`,
-`http_client`, or custom `base_url` proxies) through `extra_client_kwargs`
-when instantiating `OpenAISettings`.
-
-### Direct Response Control (Response Module)
-
-For more fine-grained control over API interactions, use the `response` module built on the standard `openai` SDK. This gives you direct access to message history, tool handlers, and custom response parsing:
-
-```python
 from openai_sdk_helpers.response import ResponseBase
-from openai_sdk_helpers import OpenAISettings
-
-# Configure OpenAI settings
-settings = OpenAISettings.from_env()
-
-# Create a response handler with custom instructions
-response = ResponseBase(
-    instructions="You are a helpful code review assistant.",
-    tools=None,  # Or provide custom tool definitions
-    output_structure=None,  # Or a Pydantic model for structured output
-    tool_handlers={},  # Map tool names to handler functions
-    openai_settings=settings
-)
-
-# Execute and get a response
-result = response.run_sync("Review this Python code for best practices...")
-print(result)
-
-# Clean up
-response.close()
-```
-
-**Key Differences:**
-- **Agent Module**: Higher-level abstraction with automatic tool handling and agent-specific workflows
-- **Response Module**: Lower-level control with manual message management, custom tool handlers, and direct API access
-
-### ResponseConfiguration Tool Validation (Strict)
-
-`ResponseConfiguration` now validates tool configuration eagerly at construction time:
-
-- `tools` must be a non-string sequence of mapping objects (for example `[{"type": "web_search"}]`).
-- String-like containers such as `"abc"`, `b"abc"`, and `bytearray(b"abc")` are invalid.
-- Each item in `tools` must be a mapping (`dict`-like). Invalid item types raise `TypeError` immediately.
-- When `add_web_search_tool=True`, `gen_response()` appends the OpenAI Responses API tool definition `{"type": "web_search"}`.
-
-Now invalid (fails fast during configuration initialization):
-
-```python
-from openai_sdk_helpers.response.configuration import ResponseConfiguration
-
-# ❌ Invalid: string containers are not tool sequences
-ResponseConfiguration(
-    name="bad_tools",
-    instructions="Use tools",
-    tools="abc",
-    input_structure=None,
-    output_structure=None,
-)
-```
-
-## Advanced Usage
-
-### Image and File Analysis
-
-The `response` module automatically detects file types and handles them appropriately:
-
-```python
-from openai_sdk_helpers.response import ResponseBase
-from openai_sdk_helpers import OpenAISettings
 
 settings = OpenAISettings.from_env()
 
 with ResponseBase(
-    name="analyzer",
-    instructions="You are a helpful assistant that can analyze files.",
+    name="reviewer",
+    instructions="Review the supplied code.",
     tools=None,
     output_structure=None,
     tool_handlers={},
     openai_settings=settings,
 ) as response:
-    # Automatic type detection - single files parameter
-    # Images are sent as base64-encoded images
-    # PDF documents are sent as base64-encoded file data
-    result = response.run_sync(
-        "Analyze these files",
-        files=["photo.jpg", "document.pdf"]
-    )
-    print(result)
-    
-    # Single file - automatically detected
-    result = response.run_sync(
-        "What's in this image?",
-        files="photo.jpg"  # Automatically detected as image
-    )
-    print(result)
-    
-    # Use vector store for RAG (Retrieval-Augmented Generation)
-    result = response.run_sync(
-        "Search these documents",
-        files=["doc1.pdf", "doc2.pdf"],
-        use_vector_store=True  # Enable RAG with vector stores
-    )
+    result = response.run_sync("Review: def add(a, b): return a + b")
     print(result)
 ```
 
-**How It Works:**
+### Agents
 
-- **Images** (jpg, png, gif, etc.) are automatically sent as base64-encoded images
-- **Documents** are sent as base64-encoded file data by default for PDFs only
-- **Non-PDF documents** should use `use_vector_store=True` (or be converted to PDF)
-- **Vector Stores** can optionally be used for documents when `use_vector_store=True`
-- **Batch Processing** is automatically used for multiple files (>3) for efficient encoding
-
-**Advanced File Processing:**
+Use `openai_sdk_helpers.agent` when the application benefits from the official
+Agents SDK loop, tools, sessions, guardrails, handoffs, or tracing.
 
 ```python
-from openai_sdk_helpers.response import process_files
-
-# Process files directly with the dedicated module
-vector_files, base64_files, images = process_files(
-    response,
-    files=["photo1.jpg", "photo2.jpg", "doc1.pdf", "doc2.pdf"],
-    use_vector_store=False,
-    batch_size=20,      # Files per batch
-    max_workers=10,     # Concurrent workers
-)
-```
-
-**Base64 Encoding Utilities:**
-
-```python
-from openai_sdk_helpers.utils import (
-    encode_image,
-    encode_file,
-    is_image_file,
-    create_image_data_url,
-    create_file_data_url,
-)
-
-# Check if a file is an image
-is_image_file("photo.jpg")  # True
-is_image_file("document.pdf")  # False
-
-# Encode an image to base64
-base64_image = encode_image("photo.jpg")
-
-# Create a data URL for an image
-image_url, detail = create_image_data_url("photo.jpg", detail="high")
-
-# Encode a file to base64
-base64_file = encode_file("document.pdf")
-
-# Create a data URL for a file
-file_data = create_file_data_url("document.pdf")
-```
-
-### Custom Prompt Templates
-
-Create custom Jinja2 templates for specialized agent behaviors:
-
-```python
-from pathlib import Path
 from openai_sdk_helpers.agent import SummarizerAgent
 
-# Use custom prompt templates
-custom_prompts = Path("./my_prompts")
-summarizer = SummarizerAgent(
-    prompt_dir=custom_prompts,
-    default_model="gpt-4o"
-)
+agent = SummarizerAgent(default_model="gpt-5-mini")
+result = agent.run_sync("Summarize this text in one sentence.")
+print(result.text)
 ```
 
-### Asynchronous Execution
+### Codex plugins
 
-All agents support both synchronous and asynchronous execution:
+Use `openai_sdk_helpers.codex` when a separately packaged capability should
+register typed commands through deterministic entry-point discovery.
+
+```bash
+openai-helpers codex plugins
+openai-helpers codex commands
+```
+
+See [docs/codex-plugins.md](docs/codex-plugins.md) for the plugin protocol,
+lifecycle, discovery, compatibility, and packaging guide.
+
+### Direct SDK calls
+
+Use the official SDK directly when a package helper would only rename
+parameters or obscure the underlying client, resource, response, event, or
+exception. Access to underlying SDK objects is part of this project's escape-
+hatch policy.
+
+The canonical inventory of shipped and planned surfaces is
+[docs/capabilities.md](docs/capabilities.md).
+
+## Core capabilities
+
+- centralized OpenAI settings and client creation;
+- Responses API orchestration, structured outputs, files, tools, and websocket helpers;
+- Agents SDK wrappers, runners, search workflows, and reusable text agents;
+- typed Pydantic structures and Jinja prompt rendering;
+- file and vector-store helpers;
+- output validation and shared tool contracts;
+- deterministic Codex plugin registration, discovery, inspection, and lifecycle;
+- optional LangExtract and Streamlit integrations;
+- local CLI inspection without hidden API calls.
+
+Detailed maturity, installation, execution, and escape-hatch information lives
+only in the [capability matrix](docs/capabilities.md).
+
+## Configuration
+
+`OpenAISettings` loads standard configuration from environment variables or a
+local `.env` file and creates official SDK clients:
 
 ```python
-import asyncio
-from openai_sdk_helpers.agent import SummarizerAgent
+from openai_sdk_helpers import OpenAISettings
 
-async def main():
-    summarizer = SummarizerAgent(default_model="gpt-4o-mini")
-    
-    # Run asynchronously
-    result = await summarizer.run_agent(
-        text="Long document to summarize...",
-        metadata={"source": "example.pdf"}
-    )
-    print(result.text)
-
-asyncio.run(main())
+settings = OpenAISettings.from_env()
+client = settings.create_client()
 ```
 
-### Vector Storage Integration
+Common variables include `OPENAI_API_KEY`, `OPENAI_ORG_ID`,
+`OPENAI_PROJECT_ID`, `OPENAI_BASE_URL`, `OPENAI_MODEL`, `OPENAI_TIMEOUT`, and
+`OPENAI_MAX_RETRIES`. Uncommon official client parameters remain available
+through `extra_client_kwargs`.
 
-Integrate with OpenAI vector stores for document search:
+## Documentation
 
-```python
-from openai_sdk_helpers.vector_storage import VectorStorage
-from openai_sdk_helpers.agent.search.vector import VectorSearch
-
-# Create or connect to a vector store
-storage = VectorStorage(store_name="my_documents")
-
-# Use it with vector search
-vector_search = VectorSearch(
-    default_model="gpt-4o-mini",
-    vector_storage=storage
-)
-```
+- [Capability matrix](docs/capabilities.md) — canonical feature inventory and maturity
+- [Public API](docs/public-api.md) — intentional import surface
+- [Installation profiles](docs/installation.md) — core and optional dependencies
+- [Codex plugins](docs/codex-plugins.md) — protocol, lifecycle, discovery, and packaging
+- [0.8 Codex migration](docs/codex-plugin-migration-0.8.md) — compatibility guidance
+- [Publishing](docs/publishing.md) — OIDC release process and recovery
+- [Product vision](PRODUCT.md) — mission, users, principles, and non-goals
+- [Roadmap](ROADMAP.md) — shipped foundations and release gates
+- [Changelog](CHANGELOG.md) — user-visible changes
 
 ## Development
 
-The repository follows standard Python development practices with comprehensive
-quality checks.
-
-### Setting Up Your Development Environment
-
 ```bash
-# Clone and install with dev dependencies
 git clone https://github.com/fatmambot33/openai-sdk-helpers.git
 cd openai-sdk-helpers
-pip install -e .[dev]
-```
+pip install -e ".[dev]"
 
-### Running Quality Checks
-
-Before opening a pull request, ensure all quality checks pass locally:
-
-```bash
-# Style and docstring checks
 pydocstyle src
-
-# Code formatting check
-black --check .
-
-# Apply formatting (if needed)
-black .
-
-# Static type checking
+black --check --diff .
 pyright src
-
-# Unit tests with coverage (minimum 70% required)
 pytest -q --cov=src --cov-report=term-missing --cov-fail-under=70
+python scripts/check_markdown_links.py
 ```
 
-All checks must pass for changes to be merged.
+Additional CI validates Python 3.10–3.13, minimum and latest compatible OpenAI
+SDK versions, built distributions, installed entry points, and isolated `core`,
+`extract`, `ui`, and `all` profiles.
 
-## Project Structure
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md) before changing
+public behavior.
 
-```
-src/openai_sdk_helpers/
-├── agent/              # Agent factories, orchestration, and search workflows
-│   ├── base.py        # Base agent class with sync/async execution
-│   ├── summarizer.py  # Text summarization agent
-│   ├── translator.py  # Translation agent
-│   ├── validation.py  # Input/output validation agent
-│   ├── vector_search.py  # Multi-agent vector search workflow
-│   └── coordinator_agent.py  # Coordinated multi-step workflows
-├── prompt/             # Jinja2 template rendering utilities
-├── response/           # Response parsing and transformation helpers
-├── structure/          # Pydantic-based typed data structures
-│   ├── base.py        # Base structure with schema generation
-│   ├── plan/          # Task and plan structures
-│   ├── summary.py     # Summary output structures
-│   └── validation.py  # Validation result structures
-├── vector_storage/     # Vector store abstraction layer
-├── configuration.py          # OpenAI settings and configuration
-└── utils/             # JSON serialization, logging, and helpers
+## Scope boundaries
 
-tests/                  # Comprehensive unit test suite
-```
+This project is not an end-user application, hosted platform, replacement SDK,
+universal agent framework, prompt catalog, or storage service. Application-
+specific business logic belongs in consuming projects.
 
-## Key Modules
-
-The package is organized around cohesive, reusable building blocks:
-
-### Agent Modules (Built on `openai-agents` SDK)
-
-These modules use the `openai-agents` SDK for high-level agent workflows with automatic tool handling and conversation management.
-
-- **`openai_sdk_helpers.agent.base.AgentBase`**  
-  Base class for all agents with synchronous and asynchronous execution support.
-  Handles prompt rendering, model configuration, and tool integration.
-
-- **`openai_sdk_helpers.agent.search.vector.VectorSearch`**  
-  Complete vector search workflow that coordinates planning, searching, and 
-  reporting. Bundles `VectorSearchPlanner`, `VectorSearchTool`, and 
-  `VectorSearchWriter` into a single entry point.
-
-- **`openai_sdk_helpers.agent.coordinator_agent.ProjectManager`**  
-  Orchestrates multi-step workflows with prompt creation, plan building, task 
-  execution, and summarization. Persists intermediate artifacts to disk.
-
-- **`openai_sdk_helpers.agent.summarizer.SummarizerAgent`**  
-  Generates concise summaries from provided text using structured output.
-
-- **`openai_sdk_helpers.agent.translator.TranslatorAgent`**  
-  Translates text into target languages with optional context.
-
-- **`openai_sdk_helpers.agent.validation.ValidatorAgent`**  
-  Validates user inputs and agent outputs against safety guardrails.
-
-### Response Module (Built on `openai` SDK)
-
-These modules use the standard `openai` SDK for direct API interactions with fine-grained control over request/response cycles.
-
-- **`openai_sdk_helpers.response.base.ResponseBase`**  
-  Manages complete OpenAI API interaction lifecycle including input construction,
-  tool execution, message history, and structured output parsing. Uses the 
-  `client.responses.create()` API (from the OpenAI Responses API, distinct from 
-  the Chat Completions API) for direct control over conversation flow.
-
-- **`openai_sdk_helpers.response.runner`**  
-  Convenience functions for executing response workflows with automatic cleanup
-  in both synchronous and asynchronous contexts.
-
-- **`openai_sdk_helpers.response.websocket.open_websocket_connection`**  
-  Opens OpenAI websocket-mode sessions while reusing `OpenAISettings`.
-  This helper wraps `client.responses.connect()` for the Responses WebSocket API.
-
-### Configuration and Data Structures (Shared)
-
-- **`openai_sdk_helpers.settings.OpenAISettings`**  
-  Centralizes OpenAI API configuration with environment variable support.
-  Creates configured OpenAI clients with consistent settings.
-
-- **`openai_sdk_helpers.structure.StructureBase`**  
-  Pydantic-based foundation for all structured outputs. Provides JSON schema
-  generation, validation, and serialization helpers.
-
-- **`openai_sdk_helpers.structure.plan`**  
-  Task and plan structures for multi-step workflows with status tracking.
-
-### Utilities (Shared)
-
-- **`openai_sdk_helpers.prompt.PromptRenderer`**  
-  Jinja2-based template rendering for dynamic prompt generation.
-
-- **`openai_sdk_helpers.vector_storage.VectorStorage`**  
-  Minimal abstraction over OpenAI vector stores with search and file management.
-
-- **`openai_sdk_helpers.utils`**  
-  JSON serialization helpers, logging utilities, and common validation functions.
-
-- **`openai_sdk_helpers.utils.langextract`**  
-  Adapter helpers for running LangExtract-style extractors and validating the
-  results into Pydantic models.
-
-## Related Projects
-
-- **[LangExtract](https://github.com/google/langextract)**  
-  Google-maintained toolkit for extracting structured data from language model
-  outputs, which can complement the validation and response utilities in
-  `openai-sdk-helpers`.
-
-## Contributing
-
-Contributions are welcome! We appreciate functional changes accompanied by
-relevant tests and documentation.
-
-### Guidelines
-
-1. **Fork and clone** the repository
-2. **Create a feature branch** from `main`
-3. **Make your changes** following the project conventions
-4. **Add or update tests** to cover your changes
-5. **Run all quality checks** (see [Development](#development))
-6. **Submit a pull request** with a clear description
-
-### Code Style
-
-- Follow **PEP 8** for Python code formatting
-- Use **NumPy-style docstrings** as outlined in `AGENTS.md`
-- Write clear, descriptive commit messages in the imperative mood
-- Keep implementations Pythonic and maintainable
-
-### Documentation
-
-- Document all public classes, methods, and functions
-- Include a `Methods` section in class docstrings listing public methods
-- Add type hints to all function signatures
-- Provide examples in docstrings where helpful
-
-### Testing
-
-- Write unit tests for new functionality
-- Maintain minimum 70% code coverage
-- Ensure all tests pass before submitting
-
-See `AGENTS.md` for detailed contributing guidelines and conventions.
+MCP, consolidated retrieval, and Realtime helpers are roadmap items, not current
+package promises. Their issue order and release gates are tracked in
+[ROADMAP.md](ROADMAP.md).
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
-for details.
-
-
-### WebSocket Mode (Responses API)
-
-WebSocket mode keeps a persistent connection to `/v1/responses` and lets you
-continue each turn by sending only incremental input plus
-`previous_response_id`.
-
-Why use WebSocket mode:
-- Lower continuation overhead for long tool-call chains.
-- Better end-to-end latency for agentic loops with many model/tool round trips.
-- Compatible with both `store=False` and Zero Data Retention workflows.
-
-```python
-from openai_sdk_helpers import (
-    OpenAISettings,
-    open_websocket_connection,
-    send_response_create,
-)
-
-settings = OpenAISettings.from_env()
-
-with open_websocket_connection(openai_settings=settings) as connection:
-    # First turn
-    first_event = send_response_create(
-        connection,
-        model="gpt-5.2",
-        store=False,
-        input_items=[
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "Find fizz_buzz()"}],
-            }
-        ],
-        tools=[],
-    )
-
-    # Optional warmup turn (no generation)
-    send_response_create(
-        connection,
-        model="gpt-5.2",
-        store=False,
-        generate=False,
-        input_items=[
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "Prepare tool state"}],
-            }
-        ],
-        tools=[],
-    )
-
-    # Continuation turn: send only new input items + previous_response_id
-    send_response_create(
-        connection,
-        model="gpt-5.2",
-        store=False,
-        previous_response_id="resp_123",
-        input_items=[
-            {
-                "type": "function_call_output",
-                "call_id": "call_123",
-                "output": "tool result",
-            },
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "Now optimize it."}],
-            },
-        ],
-        tools=[],
-    )
-
-    for event in connection:
-        print(event)
-```
-
-Operational notes:
-- Events and ordering match the Responses streaming event model.
-- One connection processes `response.create` calls sequentially (no multiplexing).
-- Connection duration is limited (typically 60 minutes), so reconnect and
-  continue with `previous_response_id` when possible.
-- Handle `previous_response_not_found` by starting a new chain and sending the
-  full context (or compacted context from `/responses/compact`).
-
-## CLI Tool
-
-The package includes a command-line tool for development and testing:
-
-```bash
-# List all registered response configurations
-openai-helpers registry list
-
-# Inspect a specific configuration
-openai-helpers registry inspect my_config
-
-# Validate Jinja2 templates
-openai-helpers template validate ./templates
-
-# Test an agent (coming soon)
-openai-helpers agent test MyAgent --input "test input"
-```
-
-### CLI Commands
-
-- **registry list** - Show all registered response configurations
-- **registry inspect** - Display details of a configuration
-- **template validate** - Check template syntax and structure
-- **agent test** - Test agents locally with sample inputs
-
-## Troubleshooting
-
-### Common Issues
-
-**"OPENAI_API_KEY is required" error**
-
-Ensure your OpenAI API key is set in the environment:
-```bash
-export OPENAI_API_KEY="your-api-key-here"
-```
-
-Or create a `.env` file in your project root:
-```
-OPENAI_API_KEY=your-api-key-here
-```
-
-**"Prompt template not found" error**
-
-Vector search workflows require custom prompt templates. Either:
-1. Create the required `.jinja` files in your `prompt_dir`
-2. Omit the `prompt_dir` parameter to use built-in defaults (for text agents only)
-3. Use the CLI to validate templates: `openai-helpers template validate ./templates`
-
-**Import errors after installation**
-
-Ensure you're using Python 3.10 or higher:
-```bash
-python --version
-```
-
-If using an older version, upgrade Python or create a virtual environment with
-Python 3.10+.
-
-**Type checking issues in your IDE**
-
-The package ships with `py.typed` for full type support. If your IDE isn't
-recognizing types:
-1. Ensure your IDE's Python plugin is up to date
-2. Restart your IDE after installing the package
-3. Check that your IDE is using the correct Python interpreter
-
-### Getting Help
-
-- Check the [Key Modules](#key-modules) section for API documentation
-- Review examples in the [Quickstart](#quickstart) and [Advanced Usage](#advanced-usage) sections
-- Open an issue on GitHub for bugs or feature requests
+Licensed under the [MIT License](LICENSE).

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,76 @@
+# Capability matrix
+
+This document is the canonical inventory of supported package capabilities.
+README content should summarize and link here rather than duplicate the matrix.
+
+Maturity meanings:
+
+- **Stable** — intentionally public and covered by compatibility policy.
+- **Supported** — production-usable, but still expected to evolve additively.
+- **Preview** — available for experimentation; compatibility may be narrower.
+- **Planned** — roadmap only and not part of the current package surface.
+
+## Current capabilities
+
+| Capability | Primary surface | SDK relationship | Maturity | Installation | Execution | Escape hatch |
+| --- | --- | --- | --- | --- | --- | --- |
+| Settings and client creation | `openai_sdk_helpers.settings` | Configures the official OpenAI Python SDK | Stable | Core | Sync construction | Returns configured official SDK clients and accepts extra client keyword arguments |
+| Responses workflows | `openai_sdk_helpers.response` | Thin orchestration over the official Responses API | Supported | Core | Sync and async paths; websocket helpers are async/stream-oriented where appropriate | Callers retain SDK configuration, response identifiers, raw events, and result objects |
+| Agents workflows | `openai_sdk_helpers.agent` | Composes the official OpenAI Agents SDK | Supported | Core | Sync and async runners | Callers retain underlying Agents SDK objects, tools, sessions, and results |
+| Typed structures | `openai_sdk_helpers.structure` | Pydantic schemas for SDK inputs and outputs | Stable | Core; extraction structures require `extract` | Local | Pydantic models and generated schemas remain directly accessible |
+| Prompt rendering | `openai_sdk_helpers.prompt` | SDK-independent Jinja rendering | Stable | Core | Local | Callers control template directories and rendered strings |
+| Tool contracts and handlers | `openai_sdk_helpers.tools` | Reusable definitions for Responses and Agents integrations | Supported | Core | Sync and async handlers where declared | Raw tool definitions and handler exceptions remain accessible |
+| Codex plugin surface | `openai_sdk_helpers.codex` and `openai_sdk_helpers.codex_cli` | Package entry-point plugin contract | Stable for 0.8 | Core | Sync and async commands; startup and shutdown lifecycle | Registry, plugin metadata, discovery reports, and original command handlers remain accessible |
+| Files API helpers | `openai_sdk_helpers.files_api` | Thin helpers over official Files resources | Supported | Core | Sync | Underlying OpenAI client and file resources remain accessible |
+| Vector-store helpers | `openai_sdk_helpers.vector_storage` and response vector-store helpers | Thin helpers over official Vector Stores and File Search resources | Supported; consolidation planned for 0.9 | Core | Primarily sync in the current public surface | Underlying client, store identifiers, and SDK resources remain accessible |
+| Responses websocket helpers | `openai_sdk_helpers.response.websocket` | Wraps the official Responses websocket connection | Preview | Core | Streaming / connection-oriented | Raw connection and events remain accessible |
+| Output validation | `openai_sdk_helpers.utils.output_validation` | SDK-independent validation adapters | Stable | Core | Local | Individual validators and original values remain accessible |
+| Document extraction | `openai_sdk_helpers.extract`, `ExtractorAgent`, extraction structures | Optional LangExtract integration plus Agents helpers | Supported | `openai-sdk-helpers[extract]` | Local and agent-driven paths | LangExtract objects, extraction models, and agent results remain accessible |
+| Streamlit application helpers | `openai_sdk_helpers.streamlit_app` | Optional UI composition layer | Supported | `openai-sdk-helpers[ui]` | Interactive | Callers own Streamlit configuration and page/application composition |
+| CLI inspection | `openai-helpers`, `openai-helpers-credentials` | Local package and configuration inspection | Supported | Core | Local command line | Commands expose registry and plugin data without hidden API calls |
+
+## Planned capabilities
+
+Planned items are not installed, exported, or implied by the current package.
+They must pass the feature acceptance test in `PRODUCT.md` before implementation.
+
+| Capability | Target | Roadmap status | Constraint |
+| --- | --- | --- | --- |
+| Shared operation context and observability | `0.8.x` | Issues #138 and #139 | Must not replace Agents SDK tracing or require a telemetry vendor |
+| Consolidated retrieval API | `0.9.0` | Issues #140–#142 | Must adapt existing file/vector-store helpers without hiding official resources |
+| MCP integration | `0.10.0` | Issues #143–#144 | Optional extra; explicit filtering, approvals, lifecycle, and failure isolation |
+| Realtime integration | `0.11.0` | Issues #145–#146 | Server-side lifecycle and event helpers only; no browser or audio-device application layer |
+
+Images and audio generation are not committed roadmap surfaces. They should be
+added only after repeated workflows demonstrate that a package-level helper is
+smaller and clearer than direct official SDK usage.
+
+## Choosing a surface
+
+Use **Responses** when the application needs direct control of request inputs,
+response identifiers, message history, tool dispatch, or raw events.
+
+Use **Agents** when the application benefits from the official Agents SDK's
+agent loop, handoffs, tools, sessions, guardrails, and tracing.
+
+Use **Codex plugins** when a separately packaged capability should register
+commands through deterministic entry-point discovery without modifying the core
+package.
+
+Use direct official SDK calls when a helper would only rename parameters or hide
+resource ownership. The package is not intended to replace either official SDK.
+
+## Documentation ownership
+
+A pull request that changes a public capability must update all applicable
+canonical documents:
+
+1. this capability matrix for surface, maturity, installation, or execution changes;
+2. `docs/public-api.md` for public import changes;
+3. `docs/installation.md` for dependency-profile changes;
+4. the relevant focused guide for behavior and examples;
+5. `CHANGELOG.md` for user-visible changes;
+6. `README.md` only when the top-level summary or primary navigation changes.
+
+The README must not grow a second capability inventory. Detailed behavior belongs
+in focused guides, and internal links are validated in CI.

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -13,7 +13,14 @@ _HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
 _HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
 _INLINE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\([^)]+\)")
 _EXTERNAL_SCHEMES = {"data", "http", "https", "mailto", "tel"}
-_IGNORED_DIRECTORIES = {".git", ".mypy_cache", ".pytest_cache", ".venv", "build", "dist"}
+_IGNORED_DIRECTORIES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "build",
+    "dist",
+}
 
 
 def _markdown_files(root: Path) -> list[Path]:
@@ -32,7 +39,9 @@ def _markdown_files(root: Path) -> list[Path]:
     return sorted(
         path
         for path in root.rglob("*.md")
-        if not any(part in _IGNORED_DIRECTORIES for part in path.relative_to(root).parts)
+        if not any(
+            part in _IGNORED_DIRECTORIES for part in path.relative_to(root).parts
+        )
     )
 
 
@@ -80,7 +89,7 @@ def _slugify_heading(heading: str) -> str:
     """
     text = _INLINE_LINK_PATTERN.sub(r"\1", heading)
     text = _HTML_TAG_PATTERN.sub("", text)
-    text = text.replace("`", "").replace("*", "").replace("_", "_")
+    text = text.replace("`", "").replace("*", "")
     text = text.strip().lower()
     text = re.sub(r"[^\w\- ]", "", text)
     text = re.sub(r"\s+", "-", text)
@@ -158,7 +167,9 @@ def check_markdown_links(root: Path) -> list[str]:
             for match in _LINK_PATTERN.finditer(line):
                 target = _link_target(match.group(1))
                 parsed = urlsplit(target)
-                if parsed.scheme.lower() in _EXTERNAL_SCHEMES or target.startswith("//"):
+                if parsed.scheme.lower() in _EXTERNAL_SCHEMES or target.startswith(
+                    "//"
+                ):
                     continue
 
                 relative_path = Path(unquote(parsed.path)) if parsed.path else Path()
@@ -184,9 +195,15 @@ def check_markdown_links(root: Path) -> list[str]:
                     )
                     continue
 
-                if parsed.fragment and destination.is_file() and destination.suffix == ".md":
+                if (
+                    parsed.fragment
+                    and destination.is_file()
+                    and destination.suffix == ".md"
+                ):
                     anchor = unquote(parsed.fragment).lower()
-                    available = anchor_cache.setdefault(destination, _anchors(destination))
+                    available = anchor_cache.setdefault(
+                        destination, _anchors(destination)
+                    )
                     if anchor not in available:
                         errors.append(
                             f"{source.relative_to(root)}:{line_number}: "

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,219 @@
+"""Validate repository-local links and anchors in Markdown files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+_LINK_PATTERN = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+_HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+_HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+_INLINE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_EXTERNAL_SCHEMES = {"data", "http", "https", "mailto", "tel"}
+_IGNORED_DIRECTORIES = {".git", ".mypy_cache", ".pytest_cache", ".venv", "build", "dist"}
+
+
+def _markdown_files(root: Path) -> list[Path]:
+    """Return tracked-style Markdown paths under a repository root.
+
+    Parameters
+    ----------
+    root : Path
+        Repository root.
+
+    Returns
+    -------
+    list[Path]
+        Sorted Markdown paths excluding generated and virtual-environment trees.
+    """
+    return sorted(
+        path
+        for path in root.rglob("*.md")
+        if not any(part in _IGNORED_DIRECTORIES for part in path.relative_to(root).parts)
+    )
+
+
+def _without_fenced_code(text: str) -> list[tuple[int, str]]:
+    """Return numbered Markdown lines outside fenced code blocks.
+
+    Parameters
+    ----------
+    text : str
+        Markdown source.
+
+    Returns
+    -------
+    list[tuple[int, str]]
+        One-based line numbers and source lines outside code fences.
+    """
+    lines: list[tuple[int, str]] = []
+    fence: str | None = None
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if marker in {"```", "~~~"}:
+            if fence is None:
+                fence = marker
+            elif marker == fence:
+                fence = None
+            continue
+        if fence is None:
+            lines.append((line_number, line))
+    return lines
+
+
+def _slugify_heading(heading: str) -> str:
+    """Approximate GitHub's Markdown heading slug generation.
+
+    Parameters
+    ----------
+    heading : str
+        Markdown heading text.
+
+    Returns
+    -------
+    str
+        Normalized anchor slug.
+    """
+    text = _INLINE_LINK_PATTERN.sub(r"\1", heading)
+    text = _HTML_TAG_PATTERN.sub("", text)
+    text = text.replace("`", "").replace("*", "").replace("_", "_")
+    text = text.strip().lower()
+    text = re.sub(r"[^\w\- ]", "", text)
+    text = re.sub(r"\s+", "-", text)
+    return re.sub(r"-+", "-", text).strip("-")
+
+
+def _anchors(path: Path) -> set[str]:
+    """Collect GitHub-style heading anchors for one Markdown file.
+
+    Parameters
+    ----------
+    path : Path
+        Markdown path.
+
+    Returns
+    -------
+    set[str]
+        Available anchors, including duplicate-heading suffixes.
+    """
+    anchors: set[str] = set()
+    occurrences: defaultdict[str, int] = defaultdict(int)
+    text = path.read_text(encoding="utf-8")
+    for _, line in _without_fenced_code(text):
+        match = _HEADING_PATTERN.match(line)
+        if match is None:
+            continue
+        base = _slugify_heading(match.group(2))
+        if not base:
+            continue
+        count = occurrences[base]
+        anchor = base if count == 0 else f"{base}-{count}"
+        occurrences[base] += 1
+        anchors.add(anchor)
+    return anchors
+
+
+def _link_target(raw_target: str) -> str:
+    """Remove optional Markdown link titles and angle brackets.
+
+    Parameters
+    ----------
+    raw_target : str
+        Text captured from a Markdown link destination.
+
+    Returns
+    -------
+    str
+        URL or path portion of the destination.
+    """
+    target = raw_target.strip()
+    if target.startswith("<") and ">" in target:
+        return target[1 : target.index(">")]
+    return target.split(maxsplit=1)[0]
+
+
+def check_markdown_links(root: Path) -> list[str]:
+    """Validate local Markdown links beneath a repository root.
+
+    Parameters
+    ----------
+    root : Path
+        Repository root.
+
+    Returns
+    -------
+    list[str]
+        Human-readable validation errors.
+    """
+    errors: list[str] = []
+    anchor_cache: dict[Path, set[str]] = {}
+
+    for source in _markdown_files(root):
+        text = source.read_text(encoding="utf-8")
+        for line_number, line in _without_fenced_code(text):
+            for match in _LINK_PATTERN.finditer(line):
+                target = _link_target(match.group(1))
+                parsed = urlsplit(target)
+                if parsed.scheme.lower() in _EXTERNAL_SCHEMES or target.startswith("//"):
+                    continue
+
+                relative_path = Path(unquote(parsed.path)) if parsed.path else Path()
+                if relative_path.is_absolute():
+                    destination = root / str(relative_path).lstrip("/")
+                else:
+                    destination = source.parent / relative_path
+                destination = destination.resolve()
+
+                try:
+                    destination.relative_to(root.resolve())
+                except ValueError:
+                    errors.append(
+                        f"{source.relative_to(root)}:{line_number}: "
+                        f"link escapes repository: {target}"
+                    )
+                    continue
+
+                if not destination.exists():
+                    errors.append(
+                        f"{source.relative_to(root)}:{line_number}: "
+                        f"missing target: {target}"
+                    )
+                    continue
+
+                if parsed.fragment and destination.is_file() and destination.suffix == ".md":
+                    anchor = unquote(parsed.fragment).lower()
+                    available = anchor_cache.setdefault(destination, _anchors(destination))
+                    if anchor not in available:
+                        errors.append(
+                            f"{source.relative_to(root)}:{line_number}: "
+                            f"missing anchor #{parsed.fragment} in "
+                            f"{destination.relative_to(root)}"
+                        )
+    return errors
+
+
+def main() -> int:
+    """Run Markdown link validation from the repository root.
+
+    Returns
+    -------
+    int
+        Zero when all local links are valid; one otherwise.
+    """
+    root = Path(__file__).resolve().parents[1]
+    errors = check_markdown_links(root)
+    if errors:
+        print("Broken internal Markdown links:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("All internal Markdown links are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add `docs/capabilities.md` as the canonical inventory of current and planned surfaces
- describe each capability by SDK relationship, maturity, installation profile, execution mode, and escape hatch
- distinguish existing Responses and Agents support from planned MCP, retrieval consolidation, and Realtime work
- replace the duplicated, oversized README feature inventory with concise product, installation, surface-selection, and documentation navigation
- define documentation ownership rules in `CONTRIBUTING.md`
- add a deterministic repository-local Markdown link and anchor checker
- run the link checker in CI
- update the changelog

## Why

Capability information was duplicated across the README and focused guides, and the README contained repeated Response and Shared Components sections. One canonical matrix makes maturity and installation promises explicit while keeping the top-level README readable.

## Validation

CI validates docstrings, formatting, typing, tests, isolated installation profiles, repository governance, and all repository-local Markdown paths and anchors.

Closes #134