### PR TITLE
Execute supported examples from the built wheel

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,61 @@
+name: Package smoke tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  installed-wheel:
+    name: Installed wheel and examples
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build --outdir package-dist
+          python -m twine check package-dist/*
+
+      - name: Install the built wheel
+        run: |
+          python -m venv .venv-wheel
+          .venv-wheel/bin/python -m pip install --upgrade pip
+          .venv-wheel/bin/python -m pip install package-dist/*.whl
+          .venv-wheel/bin/python -m pip check
+
+      - name: Verify installed package data and entry points
+        run: |
+          env -u OPENAI_API_KEY -u PYTHONPATH \
+            .venv-wheel/bin/python scripts/validate_installed_wheel.py
+          env -u OPENAI_API_KEY -u PYTHONPATH \
+            .venv-wheel/bin/openai-helpers --help
+          env -u OPENAI_API_KEY -u PYTHONPATH \
+            .venv-wheel/bin/openai-helpers-credentials --help
+
+      - name: Execute supported examples
+        run: |
+          env -u OPENAI_API_KEY -u PYTHONPATH \
+            .venv-wheel/bin/python examples/supported_responses.py
+          env -u OPENAI_API_KEY -u PYTHONPATH \
+            .venv-wheel/bin/python examples/supported_agents.py
+          env -u OPENAI_API_KEY -u PYTHONPATH \
+            .venv-wheel/bin/python examples/codex_plugin.py
+
+      - name: Upload validated distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-smoke-distributions
+          path: package-dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Added built-wheel smoke tests for both CLI entry points, runtime package data, and credential-free Responses, Agents, and Codex examples.
+- Classified examples as supported, illustrative, or deprecated with an executable compatibility policy.
 - Added a canonical capability matrix covering maturity, installation, execution, and SDK escape hatches.
 - Replaced the duplicated README feature inventory with concise canonical documentation navigation.
 - Added deterministic internal Markdown file and anchor validation to CI.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Agents SDK loop, tools, sessions, guardrails, handoffs, or tracing.
 ```python
 from openai_sdk_helpers.agent import SummarizerAgent
 
-agent = SummarizerAgent(default_model="gpt-5-mini")
+agent = SummarizerAgent(default_model="your-model")
 result = agent.run_sync("Summarize this text in one sentence.")
 print(result.text)
 ```
@@ -154,6 +154,7 @@ through `extra_client_kwargs`.
 - [Capability matrix](docs/capabilities.md) — canonical feature inventory and maturity
 - [Public API](docs/public-api.md) — intentional import surface
 - [Installation profiles](docs/installation.md) — core and optional dependencies
+- [Supported examples](examples/README.md) — executable and illustrative example policy
 - [Codex plugins](docs/codex-plugins.md) — protocol, lifecycle, discovery, and packaging
 - [0.8 Codex migration](docs/codex-plugin-migration-0.8.md) — compatibility guidance
 - [Publishing](docs/publishing.md) — OIDC release process and recovery
@@ -176,8 +177,8 @@ python scripts/check_markdown_links.py
 ```
 
 Additional CI validates Python 3.10–3.13, minimum and latest compatible OpenAI
-SDK versions, built distributions, installed entry points, and isolated `core`,
-`extract`, `ui`, and `all` profiles.
+SDK versions, built distributions, installed entry points, supported examples,
+and isolated `core`, `extract`, `ui`, and `all` profiles.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md) before changing
 public behavior.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,61 @@
+# Examples
+
+Examples are classified by the compatibility promise they carry.
+
+## Supported smoke examples
+
+Supported examples are deterministic, credential-free, and executed from the
+built wheel in CI. A public API change must update these examples in the same
+pull request.
+
+| Example | Surface | Network behavior |
+| --- | --- | --- |
+| `supported_responses.py` | Responses configuration and registry | No API call |
+| `supported_agents.py` | Agents configuration and official SDK agent construction | No API call |
+| `codex_plugin.py` | Codex plugin lifecycle plus sync and async commands | No API call |
+
+Run them after installing the package:
+
+```bash
+python examples/supported_responses.py
+python examples/supported_agents.py
+python examples/codex_plugin.py
+```
+
+## Illustrative examples
+
+The remaining examples demonstrate broader workflows or integration patterns.
+They are reviewed for usefulness, but they are not part of the executable
+compatibility contract and may require credentials, files, optional extras, or
+external API calls:
+
+- `automatic_file_detection.py`
+- `classify.py`
+- `image_and_file_support.py`
+- `registry_features_demo.py`
+- `textextract.py`
+- `tool_spec_usage_example.py`
+- `tool_wrapper_and_async_demo.py`
+
+Illustrative examples must state their prerequisites in their module docstring
+when they require credentials, external files, or an optional installation
+profile.
+
+## Deprecated examples
+
+No example is currently designated deprecated. When an example no longer
+represents a supported workflow, mark it deprecated here, add its replacement,
+and remove it only under the package compatibility policy.
+
+## Policy
+
+A supported example must:
+
+- run from an installed wheel rather than an editable source install;
+- avoid `OPENAI_API_KEY` and external network access;
+- use intentional public imports;
+- assert its expected behavior instead of only printing output;
+- complete on every pull request in the package smoke workflow.
+
+Examples that need live OpenAI behavior remain illustrative and belong in a
+separate opt-in integration environment, not pull-request CI.

--- a/examples/supported_agents.py
+++ b/examples/supported_agents.py
@@ -1,0 +1,29 @@
+"""Build an Agents SDK agent without making an API call."""
+
+from __future__ import annotations
+
+from openai_sdk_helpers.agent import AgentConfiguration, AgentRegistry
+
+
+def main() -> None:
+    """Run the deterministic Agents configuration workflow."""
+    registry = AgentRegistry()
+    configuration = AgentConfiguration(
+        name="example_agent",
+        instructions="Answer clearly and preserve the caller's intent.",
+        model="example-model",
+    )
+
+    registry.register(configuration)
+    helper = registry.get("example_agent").gen_agent()
+    sdk_agent = helper.get_agent()
+
+    assert helper.name == "example_agent"
+    assert helper.instructions_text.startswith("Answer clearly")
+    assert sdk_agent.name == "example_agent"
+    assert sdk_agent.model == "example-model"
+    print("Agents configuration workflow passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/supported_responses.py
+++ b/examples/supported_responses.py
@@ -1,0 +1,29 @@
+"""Build and inspect a Responses configuration without an API call."""
+
+from __future__ import annotations
+
+from openai_sdk_helpers.response import ResponseConfiguration, ResponseRegistry
+
+
+def main() -> None:
+    """Run the deterministic Responses configuration workflow."""
+    registry = ResponseRegistry()
+    configuration = ResponseConfiguration(
+        name="example_responder",
+        instructions="Return a concise answer.",
+        tools=[{"type": "web_search"}],
+        input_structure=None,
+        output_structure=None,
+    )
+
+    registry.register(configuration)
+    registered = registry.get("example_responder")
+
+    assert registered is configuration
+    assert registered.name == "example_responder"
+    assert registered.tools == [{"type": "web_search"}]
+    print("Responses configuration workflow passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_installed_wheel.py
+++ b/scripts/validate_installed_wheel.py
@@ -1,0 +1,79 @@
+"""Validate runtime contents from an installed package wheel."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from importlib import resources
+from importlib.metadata import distribution
+from pathlib import Path
+
+_DISTRIBUTION_NAME = "openai-sdk-helpers"
+_PACKAGE_NAME = "openai_sdk_helpers"
+_REQUIRED_CONSOLE_SCRIPTS = {
+    "openai-helpers",
+    "openai-helpers-credentials",
+}
+_REQUIRED_PACKAGE_FILES = {
+    "openai_sdk_helpers/py.typed",
+    "openai_sdk_helpers/prompt/summarizer.jinja",
+    "openai_sdk_helpers/prompt/translator.jinja",
+    "openai_sdk_helpers/prompt/validator.jinja",
+    "openai_sdk_helpers/prompt/vector_planner.jinja",
+}
+
+
+def main() -> int:
+    """Validate the installed distribution and its runtime package data.
+
+    Returns
+    -------
+    int
+        Zero when the installed wheel contains every required runtime surface.
+    """
+    if os.environ.get("OPENAI_API_KEY"):
+        raise AssertionError("Installed-wheel validation must run without credentials")
+
+    package = importlib.import_module(_PACKAGE_NAME)
+    package_path = Path(package.__file__ or "").resolve()
+    if not package_path.is_file():
+        raise AssertionError("Installed package does not have a resolvable module path")
+
+    installed_distribution = distribution(_DISTRIBUTION_NAME)
+    installed_files = {
+        str(path).replace("\\", "/")
+        for path in (installed_distribution.files or ())
+    }
+    missing_files = sorted(_REQUIRED_PACKAGE_FILES - installed_files)
+    if missing_files:
+        raise AssertionError(f"Wheel is missing runtime files: {missing_files}")
+
+    console_scripts = {
+        entry_point.name
+        for entry_point in installed_distribution.entry_points
+        if entry_point.group == "console_scripts"
+    }
+    missing_scripts = sorted(_REQUIRED_CONSOLE_SCRIPTS - console_scripts)
+    if missing_scripts:
+        raise AssertionError(f"Wheel is missing console scripts: {missing_scripts}")
+
+    package_resources = resources.files(_PACKAGE_NAME)
+    if not package_resources.joinpath("py.typed").is_file():
+        raise AssertionError("py.typed is not accessible through importlib.resources")
+
+    prompt_resources = resources.files(f"{_PACKAGE_NAME}.prompt")
+    for prompt_name in (
+        "summarizer.jinja",
+        "translator.jinja",
+        "validator.jinja",
+        "vector_planner.jinja",
+    ):
+        if not prompt_resources.joinpath(prompt_name).is_file():
+            raise AssertionError(f"Prompt template is unavailable: {prompt_name}")
+
+    print(f"Installed wheel validated at {package_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_installed_wheel.py
+++ b/scripts/validate_installed_wheel.py
@@ -41,8 +41,7 @@ def main() -> int:
 
     installed_distribution = distribution(_DISTRIBUTION_NAME)
     installed_files = {
-        str(path).replace("\\", "/")
-        for path in (installed_distribution.files or ())
+        str(path).replace("\\", "/") for path in (installed_distribution.files or ())
     }
     missing_files = sorted(_REQUIRED_PACKAGE_FILES - installed_files)
     if missing_files:


### PR DESCRIPTION
## What changed

- classify repository examples as supported, illustrative, or deprecated
- add deterministic Responses and Agents supported examples
- retain the Codex plugin lifecycle example as the supported Codex workflow
- add an installed-wheel validator for `py.typed`, bundled prompt templates, and both console scripts
- build wheel and source distributions in a dedicated package smoke workflow
- install and test the exact wheel in a clean virtual environment
- execute all supported examples with `OPENAI_API_KEY` and `PYTHONPATH` unset
- run both CLI help entry points from the installed distribution
- upload the validated distributions as workflow artifacts
- document the example compatibility policy and update the changelog

## Why

Unit tests alone do not prove that package data, entry points, public examples, or the built wheel remain usable. This creates an executable release-level contract without credentials, external network calls, or paid API requests.

## Validation

The new Package smoke tests workflow validates the exact built artifacts. Existing CI continues to cover formatting, docstrings, typing, Python 3.10–3.13, optional installation profiles, and repository governance.

Closes #135