### PR TITLE
Define security reporting and release review policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Added a security policy using confidential GitHub private vulnerability reporting and an explicit supported-version transition.
+- Added a security-aware release checklist covering credentials, publishing, files, plugins, tools, transports, diagnostics, and artifact verification.
+- Replaced a secret-shaped example value with an explicit non-secret placeholder.
 - Added built-wheel smoke tests for both CLI entry points, runtime package data, and credential-free Responses, Agents, and Codex examples.
 - Classified examples as supported, illustrative, or deprecated with an executable compatibility policy.
 - Added a canonical capability matrix covering maturity, installation, execution, and SDK escape hatches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing
 
+Security vulnerabilities must not be reported in public issues. Follow the
+confidential process in [SECURITY.md](SECURITY.md).
+
 ## Workflow
 
 1. Open or select one focused issue.
@@ -38,6 +41,8 @@ A public change must update every applicable canonical document:
 - [docs/public-api.md](docs/public-api.md) for intentional import changes;
 - [docs/installation.md](docs/installation.md) for dependency profiles;
 - the focused behavior guide for semantics and examples;
+- [SECURITY.md](SECURITY.md) for trust-boundary or supported-version changes;
+- [docs/release-checklist.md](docs/release-checklist.md) for release-gate changes;
 - [CHANGELOG.md](CHANGELOG.md) for user-visible changes;
 - [README.md](README.md) only when top-level navigation or the product summary changes.
 
@@ -60,6 +65,18 @@ Public additions require:
 Breaking changes, deprecations, security-sensitive defaults, releases, and new
 public contracts require human review even when implementation is automated.
 
+## Security-sensitive changes
+
+Use the security section of [docs/release-checklist.md](docs/release-checklist.md)
+when changing credentials, publishing, files, plugins, tools, external
+transports, diagnostics, tracing, subprocesses, or destructive resource
+operations. Pull requests must explain trust boundaries, redaction, ownership,
+cleanup, cancellation, and failure isolation where applicable.
+
+Examples, tests, fixtures, screenshots, and documentation must contain
+placeholder credentials and synthetic data only. Do not copy production logs,
+prompts, responses, files, or tool arguments into a pull request.
+
 ## Pull-request completion
 
 A pull request is ready to merge only when:
@@ -70,4 +87,5 @@ A pull request is ready to merge only when:
 - optional integrations remain outside the base installation;
 - no credential, paid API call, or external network dependency is required by
   pull-request tests;
+- applicable security review items are completed by a human reviewer;
 - the linked issue's acceptance criteria are genuinely satisfied.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Small, typed, SDK-first primitives for composing OpenAI Responses, Agents,
 files, vector stores, tools, and Codex plugins.
 
 [Install](#installation) · [Choose a surface](#choose-a-surface) ·
-[Capabilities](docs/capabilities.md) · [Public API](docs/public-api.md) ·
+[Capabilities](docs/capabilities.md) · [Security](SECURITY.md) ·
 [Roadmap](ROADMAP.md)
 
 </div>
@@ -149,12 +149,22 @@ Common variables include `OPENAI_API_KEY`, `OPENAI_ORG_ID`,
 `OPENAI_MAX_RETRIES`. Uncommon official client parameters remain available
 through `extra_client_kwargs`.
 
+## Security
+
+Report suspected vulnerabilities through the repository's confidential GitHub
+private vulnerability reporting flow, not a public issue. Never include real
+credentials, customer prompts, model responses, uploaded files, or production
+logs. See [SECURITY.md](SECURITY.md) for supported versions, reporting guidance,
+and trust boundaries.
+
 ## Documentation
 
 - [Capability matrix](docs/capabilities.md) — canonical feature inventory and maturity
 - [Public API](docs/public-api.md) — intentional import surface
 - [Installation profiles](docs/installation.md) — core and optional dependencies
 - [Supported examples](examples/README.md) — executable and illustrative example policy
+- [Security policy](SECURITY.md) — confidential reporting and supported versions
+- [Release checklist](docs/release-checklist.md) — security and publication gates
 - [Codex plugins](docs/codex-plugins.md) — protocol, lifecycle, discovery, and packaging
 - [0.8 Codex migration](docs/codex-plugin-migration-0.8.md) — compatibility guidance
 - [Publishing](docs/publishing.md) — OIDC release process and recovery

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,105 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Use GitHub private vulnerability reporting for this repository:
+
+1. Open the repository **Security** tab.
+2. Select **Advisories**.
+3. Select **Report a vulnerability**.
+
+This creates a confidential security advisory visible only to the reporter and
+repository security maintainers. Private vulnerability reporting is enabled for
+this repository.
+
+Do not include real API keys, access tokens, customer prompts, model responses,
+uploaded files, personal data, or production logs. Revoke and rotate any secret
+that may already have been exposed before submitting the report.
+
+A useful report includes:
+
+- the affected package version and commit, when known;
+- Python version and operating system;
+- the smallest safe reproducer using placeholder credentials and synthetic data;
+- expected and observed behavior;
+- security impact and the conditions required to trigger it;
+- whether credentials, files, plugin commands, tools, or external services are involved;
+- suggested remediation, when available.
+
+The maintainers will acknowledge the report, investigate its scope, coordinate a
+fix and disclosure plan when appropriate, and publish an advisory after affected
+users have a reasonable upgrade path. Response and remediation timing depends on
+severity, reproducibility, maintainer availability, and upstream SDK behavior;
+this project does not promise fixed response-time targets.
+
+## Supported versions
+
+Until `0.8.0` is published, the latest `0.7.x` release is the supported release
+line. After `0.8.0` is published, support moves to the latest `0.8.x` release and
+older `0.7.x` releases no longer receive routine security fixes.
+
+| Release line | Security support |
+| --- | --- |
+| Latest published minor line | Supported |
+| Older minor lines | Upgrade required |
+| Unreleased development branches | Best effort; not a supported release |
+
+Security fixes are normally released in the newest compatible patch or minor
+release. A severe vulnerability may require a breaking change when a safe
+backward-compatible fix is not possible; such a decision requires explicit
+human review and migration guidance.
+
+## Security boundaries
+
+### Credentials and configuration
+
+- API keys and tokens must come from caller-owned environment or secret stores.
+- The package must not log, serialize, commit, or persist credentials by default.
+- Examples and tests must use placeholders only.
+- Diagnostic output must redact secrets and avoid printing complete
+  authorization headers.
+- A credential exposed in an issue, log, commit, artifact, or screenshot must be
+  revoked rather than merely deleted from the visible surface.
+
+### Prompts, responses, and tracing
+
+Prompts, tool arguments, model responses, uploaded content, and trace data may be
+sensitive. New diagnostics or observability features must exclude content by
+default or require explicit caller opt-in, document retention behavior, and
+preserve access to underlying official SDK controls.
+
+### Files and vector stores
+
+File upload, download, search, deletion, and cleanup operations must make network
+calls and destructive actions explicit. Helpers must not automatically delete
+caller-owned resources or expose file contents in logs. Tests use synthetic data
+and mocked network boundaries.
+
+### Plugins and tools
+
+Codex plugins and tool handlers execute caller-provided code. Discovery must not
+silently execute commands. Plugin startup, tool invocation, approvals, failure
+isolation, and shutdown must remain explicit. Unknown or mutating tools must not
+be granted broader trust merely because they were discovered successfully.
+
+### Optional and external integrations
+
+Optional integrations remain outside the base installation. MCP, Realtime, UI,
+extraction, and future external-service adapters must define trust boundaries,
+resource ownership, cancellation, failure behavior, and credential handling
+before becoming public capabilities.
+
+### Dependency and supply-chain changes
+
+Dependency-bound changes, release workflows, artifact attestations, publishing
+identity, and credential migration require review against
+[docs/release-checklist.md](docs/release-checklist.md). Package publication uses
+PyPI Trusted Publishing and must not fall back to a long-lived PyPI API token.
+
+## Public discussion
+
+After a fix or advisory is public, normal discussion may continue in issues or
+pull requests. Before disclosure, keep exploit details, affected deployments,
+private patches, and reproducer material inside the private security advisory.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,83 @@
+# Release checklist
+
+Use this checklist for every public package release. Release publication and
+security-sensitive decisions require explicit human approval even when agents
+prepare the code, artifacts, and release notes.
+
+## Scope and compatibility
+
+- [ ] The release contains only approved issue scope.
+- [ ] Public additions satisfy the feature acceptance test in `PRODUCT.md`.
+- [ ] Breaking changes and deprecations have explicit migration guidance.
+- [ ] `docs/capabilities.md`, `docs/public-api.md`, focused guides, README, and
+      changelog agree with the shipped surface.
+- [ ] Optional integrations remain outside the base installation.
+- [ ] Underlying OpenAI SDK clients, resources, results, events, and exceptions
+      remain available where promised.
+
+## Security review
+
+Require named human review when a release changes any of the following:
+
+- credentials, environment loading, authentication, or secret storage;
+- package publishing, GitHub Actions permissions, OIDC identity, attestations,
+  artifacts, or dependency bounds;
+- file upload, download, vector-store lifecycle, deletion, or cleanup;
+- plugin discovery, startup, shutdown, command execution, or entry points;
+- tool execution, approvals, MCP servers, external transports, or network trust;
+- prompt, response, trace, diagnostic, log, or telemetry content;
+- Realtime sessions, cancellation, reconnection, audio buffers, or event handling;
+- sandboxing, subprocesses, filesystem access, or serialization of untrusted data.
+
+For an applicable change, confirm:
+
+- [ ] credentials and authorization headers are never logged or serialized;
+- [ ] examples, tests, fixtures, screenshots, and documentation use placeholders;
+- [ ] sensitive prompts, responses, files, and tool arguments are excluded from
+      diagnostics by default;
+- [ ] destructive actions require explicit caller intent;
+- [ ] resource ownership, cleanup, cancellation, and failure isolation are documented;
+- [ ] unknown plugins or tools are not silently trusted or executed;
+- [ ] dependency and workflow permissions are minimal and justified;
+- [ ] vulnerability reporting instructions remain accurate and confidential.
+
+## Automated validation
+
+- [ ] `pydocstyle src` passes.
+- [ ] `black --check --diff .` passes.
+- [ ] `pyright src` passes.
+- [ ] tests pass with the configured coverage threshold.
+- [ ] Python 3.10–3.13 pass.
+- [ ] minimum and latest supported OpenAI SDK dependency sets pass.
+- [ ] internal Markdown links and anchors pass.
+- [ ] `core`, `extract`, `ui`, and `all` clean-install profiles pass.
+- [ ] wheel and source distributions build and pass metadata validation.
+- [ ] the exact wheel installs in a clean environment.
+- [ ] both CLI entry points and supported examples run without credentials.
+- [ ] required runtime package data and `py.typed` are present.
+
+## Release artifacts
+
+- [ ] The canonical version is updated consistently.
+- [ ] The changelog has a dated release section.
+- [ ] Release notes explain user-visible changes, compatibility, and migration.
+- [ ] The wheel and source distribution are built once and reused.
+- [ ] The validated artifacts have a CycloneDX SBOM and GitHub attestations.
+- [ ] PyPI Trusted Publisher identity matches the documented owner, repository,
+      workflow, and protected environment.
+- [ ] No `PYPI_API_TOKEN` fallback is enabled.
+- [ ] The GitHub release and PyPI publication use the same commit and artifacts.
+
+## Publication and verification
+
+- [ ] A human approves the protected `pypi` environment deployment.
+- [ ] PyPI shows the intended immutable version and attestations.
+- [ ] The matching `v<version>` GitHub release contains the distributions and SBOM.
+- [ ] A clean environment installs the version from PyPI.
+- [ ] package import, `openai-helpers --help`, and
+      `openai-helpers-credentials --help` succeed after publication.
+- [ ] The release issue records validation evidence and any approved exception.
+
+Do not publish when a required item is unknown. Record the exact blocker instead
+of weakening a check, bypassing OIDC, inventing an approval, or claiming a gate
+is complete.

--- a/examples/registry_features_demo.py
+++ b/examples/registry_features_demo.py
@@ -168,9 +168,9 @@ def example_settings_builder():
     print("\n=== Example 4: Settings Builder ===")
 
     try:
-        # Build settings with validation
+        # Build settings with a non-secret placeholder value.
         settings = build_openai_settings(
-            api_key="sk-test-key-example",
+            api_key="example-api-key-placeholder",
             default_model="gpt-4o",
             timeout="30.5",  # String parsed to float
             max_retries="3",  # String parsed to int


### PR DESCRIPTION
## What changed

- add `SECURITY.md` using the repository's enabled GitHub private vulnerability reporting flow
- define the supported-release-line transition from 0.7.x to 0.8.x
- document credential, prompt/response, file, vector-store, plugin, tool, optional integration, and supply-chain boundaries
- add `docs/release-checklist.md` with explicit security, compatibility, artifact, publication, and post-release gates
- link confidential reporting and release review guidance from README and CONTRIBUTING
- require human review for security-sensitive changes
- replace a secret-shaped example value with an explicit non-secret placeholder
- update the changelog

## Why

The package handles credentials, files, plugins, tools, external integrations, and release publishing. Users and contributors need a verified confidential reporting route and maintainers need a concrete security review contract before the 0.8.0 release.

## Validation

GitHub private vulnerability reporting is enabled for this repository. CI validates documentation links, formatting, typing, Python 3.10–3.13, optional installation profiles, installed-wheel examples, and repository governance.

Closes #136