### PR TITLE
Approve the retrieval architecture and migration map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
+- Added preview retrieval contracts for OpenAI files, vector stores, direct search results, and File Search configuration with raw SDK escape hatches.
+- Added a migration map separating resource lifecycle, search configuration, and message composition while preserving every existing retrieval import pending adapters.
 - Added explicit `AgentRunState`, `ResponseContinuation`, and `LocalMessageStore` contracts for Agents sessions, server-managed continuation, and package-local message persistence.
 - Added early validation for incompatible state mechanisms while preserving existing stateless calls, raw SDK identifiers, underlying session objects, and the legacy `session=` shorthand.
 - Added an optional typed `OperationContext` with sync and async lifecycle hooks across Responses runners, Agents runners, and Codex command execution.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -17,6 +17,7 @@ Maturity meanings:
 | Settings and client creation | `openai_sdk_helpers.settings` | Configures the official OpenAI Python SDK | Stable | Core | Sync construction | Returns configured official SDK clients and accepts extra client keyword arguments |
 | Shared operation context | `openai_sdk_helpers.runtime` | Vendor-neutral lifecycle metadata that complements, but does not replace, official SDK tracing | Preview | Core | Sync and async observers | Original results and exceptions remain unchanged; Agents SDK tracing remains directly configurable |
 | Explicit conversation state | `openai_sdk_helpers.state` and Agents runners | Validates official Agents session and server-continuation choices; provides explicit local `ResponseMessages` storage | Preview | Core | Local validation plus matching sync/async runner forwarding | Underlying session objects, response IDs, conversation IDs, request kwargs, and message collections remain accessible |
+| Retrieval architecture contracts | `openai_sdk_helpers.retrieval` | Models official Files, Vector Stores, direct search, and File Search configuration without implementing network calls yet | Preview | Core | Local contracts only in #140 | Every normalized object preserves raw SDK resources; injected client protocols expose the official client |
 | Responses workflows | `openai_sdk_helpers.response` | Thin orchestration over the official Responses API | Supported | Core | Sync and async paths; websocket helpers are async/stream-oriented where appropriate | Callers retain SDK configuration, response identifiers, raw events, and result objects |
 | Agents workflows | `openai_sdk_helpers.agent` | Composes the official OpenAI Agents SDK | Supported | Core | Sync and async runners | Callers retain underlying Agents SDK objects, tools, sessions, and results |
 | Typed structures | `openai_sdk_helpers.structure` | Pydantic schemas for SDK inputs and outputs | Stable | Core; extraction structures require `extract` | Local | Pydantic models and generated schemas remain directly accessible |
@@ -24,7 +25,7 @@ Maturity meanings:
 | Tool contracts and handlers | `openai_sdk_helpers.tools` | Reusable definitions for Responses and Agents integrations | Supported | Core | Sync and async handlers where declared | Raw tool definitions and handler exceptions remain accessible |
 | Codex plugin surface | `openai_sdk_helpers.codex` and `openai_sdk_helpers.codex_cli` | Package entry-point plugin contract | Stable for 0.8 | Core | Sync and async commands; startup and shutdown lifecycle | Registry, plugin metadata, discovery reports, and original command handlers remain accessible |
 | Files API helpers | `openai_sdk_helpers.files_api` | Thin helpers over official Files resources | Supported | Core | Sync | Underlying OpenAI client and file resources remain accessible |
-| Vector-store helpers | `openai_sdk_helpers.vector_storage` and response vector-store helpers | Thin helpers over official Vector Stores and File Search resources | Supported; consolidation planned for 0.9 | Core | Primarily sync in the current public surface | Underlying client, store identifiers, and SDK resources remain accessible |
+| Vector-store helpers | `openai_sdk_helpers.vector_storage` and response vector-store helpers | Thin helpers over official Vector Stores and File Search resources | Supported; compatibility adapters planned for 0.9 | Core | Primarily sync in the current public surface | Underlying client, store identifiers, and SDK resources remain accessible |
 | Responses websocket helpers | `openai_sdk_helpers.response.websocket` | Wraps the official Responses websocket connection | Preview | Core | Streaming / connection-oriented | Raw connection and events remain accessible |
 | Output validation | `openai_sdk_helpers.utils.output_validation` | SDK-independent validation adapters | Stable | Core | Local | Individual validators and original values remain accessible |
 | Document extraction | `openai_sdk_helpers.extract`, `ExtractorAgent`, extraction structures | Optional LangExtract integration plus Agents helpers | Supported | `openai-sdk-helpers[extract]` | Local and agent-driven paths | LangExtract objects, extraction models, and agent results remain accessible |
@@ -38,7 +39,8 @@ They must pass the feature acceptance test in `PRODUCT.md` before implementation
 
 | Capability | Target | Roadmap status | Constraint |
 | --- | --- | --- | --- |
-| Consolidated retrieval API | `0.9.0` | Issues #140–#142 | Must adapt existing file/vector-store helpers without hiding official resources |
+| Retrieval lifecycle implementation | `0.9.0` | Issue #141 | Implement the approved #140 sync/async contracts with injected SDK clients, explicit ownership, and compatibility adapters |
+| File Search adapters and normalized results | `0.9.0` | Issue #142 | Consume the approved configuration and result models without hiding filters, ranking, content, or raw resources |
 | MCP integration | `0.10.0` | Issues #143–#144 | Optional extra; explicit filtering, approvals, lifecycle, and failure isolation |
 | Realtime integration | `0.11.0` | Issues #145–#146 | Server-side lifecycle and event helpers only; no browser or audio-device application layer |
 

--- a/docs/retrieval.md
+++ b/docs/retrieval.md
@@ -1,0 +1,216 @@
+# Retrieval architecture and migration map
+
+The target retrieval package is `openai_sdk_helpers.retrieval`. It uses official
+OpenAI terminology and separates three concerns:
+
+1. Files API resource lifecycle;
+2. vector-store lifecycle and direct search;
+3. File Search tool configuration and application message composition.
+
+Issue #140 approves contracts and migration boundaries only. Network operations
+are implemented in #141 and File Search request/result adapters in #142.
+
+## Design principles
+
+- The caller injects an official `OpenAI` or `AsyncOpenAI` client.
+- The helper never silently constructs a client from an API key.
+- Files and vector stores remain distinct resources.
+- Attaching a file to a vector store does not transfer ownership of the Files
+  resource.
+- Detaching a vector-store file does not delete the underlying Files resource.
+- File and vector-store deletion are separate, explicit operations.
+- Store creation, chunking, attributes, expiration, filters, ranking, query
+  rewriting, and result limits remain visible.
+- Every normalized resource or result preserves the original SDK object through
+  `raw`.
+- Sync and async implementations share models but use separate protocols.
+- Application message construction remains outside resource lifecycle clients.
+- No non-OpenAI vector database abstraction is introduced.
+
+## Target public surface
+
+The architecture contract exports from `openai_sdk_helpers.retrieval`:
+
+- `UploadedFile`
+- `VectorStoreReference`
+- `RetrievalOperationResult`
+- `RetrievalSearchContent`
+- `RetrievalSearchResult`
+- `RetrievalSearchPage`
+- `FileSearchConfig`
+- `SyncRetrievalClient`
+- `AsyncRetrievalClient`
+- `FileSource`
+- `AttributeValue`
+
+These names are intentionally not package-root exports during preview. Import
+from the focused module so the 0.9 review can evolve the surface without
+expanding the already-large package root.
+
+## Resource models
+
+### Uploaded files
+
+`UploadedFile` normalizes the official file identifier, filename, purpose, and
+optional byte count. The underlying SDK `FileObject` remains available as
+`raw`.
+
+Uploading a file does not imply:
+
+- vector-store creation;
+- attachment to a vector store;
+- automatic cleanup;
+- expiration unless explicitly requested;
+- ownership transfer to a response or agent wrapper.
+
+### Vector stores
+
+`VectorStoreReference` holds a store ID, optional name, and the raw official SDK
+resource. Name lookup is not part of the identity contract because names are not
+unique resource identifiers.
+
+### Operation outcomes
+
+`RetrievalOperationResult[T]` records the operation name, normalized resource,
+success flag, raw SDK response, and optional original exception for explicit
+batch or cleanup workflows. Ordinary single-resource methods may still raise the
+original SDK exception. Implementations must document which behavior they use.
+
+### Search results
+
+`RetrievalSearchResult` normalizes source file identity, relevance score,
+attributes, and ordered text fragments while preserving the raw result item.
+`RetrievalSearchPage` preserves query strings, order, pagination state, and the
+raw SDK page.
+
+Normalization does not synthesize citations, summarize content, or discard
+attributes. Applications retain full control over presentation and prompting.
+
+## File Search configuration
+
+`FileSearchConfig` represents only the official File Search tool settings:
+
+- vector-store IDs;
+- maximum result count;
+- attribute filters;
+- ranking options;
+- whether Responses should include raw File Search results.
+
+`as_tool()` creates an SDK-shaped tool dictionary. `response_includes()` returns
+`file_search_call.results` only when explicitly requested. Store creation,
+upload, and search execution are separate operations.
+
+## Client protocols
+
+`SyncRetrievalClient` and `AsyncRetrievalClient` define matching operations:
+
+- upload a file;
+- create a vector store;
+- attach an existing file;
+- detach a file without deleting it;
+- search a vector store;
+- delete an underlying file;
+- delete a vector store;
+- expose the injected official SDK client.
+
+The protocols deliberately do not define:
+
+- implicit context-manager deletion;
+- global registries;
+- automatic name lookup;
+- automatic upload when configuring File Search;
+- automatic deletion after a response;
+- a proprietary filter language;
+- a generic third-party vector database API.
+
+## Existing-surface inventory
+
+| Existing surface | Current behavior | Decision | Migration boundary |
+| --- | --- | --- | --- |
+| `FilesAPIManager` | Files CRUD, batch upload, tracking, context-manager cleanup, default `user_data` expiration | **Adapt and deprecate gradually** | Implement the new file operations with injected client and explicit ownership; retain legacy class as an adapter for at least one minor line |
+| `FilePurpose` | Literal purpose alias | **Keep temporarily** | Re-export or alias from the implementation until official SDK typing can be used directly without compatibility loss |
+| `VectorStorage` | Store creation/discovery, uploads, downloads, deletion, cleanup, implicit ownership | **Adapt** | Use as implementation input, then route public lifecycle through the new client while preserving existing imports |
+| `VectorStorageFileInfo` / `VectorStorageFileStats` | Batch status and error summaries | **Deprecate after adapters ship** | Map to `RetrievalOperationResult` collections; no immediate removal |
+| `vector_storage.cleanup` | Best-effort tracked cleanup | **Internalize** | Keep explicit cleanup utilities behind the implementation; never make cleanup implicit in the new protocol |
+| `response.files.process_files` | Inline encoding plus hidden vector-store creation/upload and response-owned cleanup | **Split** | Keep inline image/PDF composition; route vector lifecycle through an injected retrieval client and require explicit ownership |
+| `response.vector_store.attach_vector_store` | Resolves non-unique names, may construct a client, mutates protected response tool state | **Deprecate** | Replace with explicit store IDs and `FileSearchConfig`; keep a compatibility adapter during 0.9 |
+| `agent.files.build_agent_input_messages` | Uploads documents while composing input messages | **Keep and adapt** | Accept an injected retrieval uploader; message construction remains in the Agents surface |
+| `agent.search.vector` | Agent orchestration over File Search | **Keep** | Consume `FileSearchConfig` and retrieval references without owning remote resource lifecycle |
+| `structure.vector_search` | Application-oriented plan/report schemas | **Keep** | Not a resource or raw search-result model; remains separate |
+| `response` and `agent` private vector fields | Hidden store ownership and cleanup | **Internalize then remove privately** | Preserve behavior until migration tests exist; new code must use explicit lifecycle contracts |
+
+## Compatibility and deprecation plan
+
+### 0.9 preview
+
+- Add the retrieval contracts and implementations.
+- Keep every existing import working.
+- Add adapters from legacy classes and helpers.
+- Emit deprecation warnings only where a complete replacement exists.
+- Document destructive and network behavior at each call site.
+
+### Following minor line
+
+- Prefer `openai_sdk_helpers.retrieval` in examples and documentation.
+- Stop expanding legacy managers.
+- Keep compatibility adapters and migration tests.
+- Review whether package-root legacy exports remain justified.
+
+### Future major release
+
+Removal is considered only after:
+
+- at least one documented deprecation window;
+- equivalent sync/async functionality;
+- migration guidance for ownership and cleanup;
+- evidence that public consumers can preserve raw SDK access;
+- explicit human approval.
+
+## Ownership examples
+
+### Caller-owned resources
+
+The default new-client contract treats uploaded files and vector stores as
+caller-owned. Closing the client does not delete them.
+
+```python
+file_result = retrieval.upload_file("guide.pdf", purpose="user_data")
+store_result = retrieval.create_vector_store(
+    name="guides",
+    file_ids=(file_result.resource.id,),
+)
+```
+
+Deletion remains two explicit actions when both resources should be removed:
+
+```python
+retrieval.delete_vector_store(store_result.resource.id)
+retrieval.delete_file(file_result.resource.id)
+```
+
+### Temporary workflows
+
+Applications may build their own scoped cleanup policy from returned operation
+results. The package may offer an explicit owned-resource scope in a later issue,
+but it must list resources before deletion, preserve partial failures, and never
+claim ownership of externally supplied IDs.
+
+## Security and diagnostics
+
+Files and search content may be sensitive. Implementations must:
+
+- avoid logging file bytes, extracted text, query content, filters, or attributes
+  by default;
+- integrate optional `OperationContext` metadata without exporting content;
+- preserve original SDK exceptions;
+- make destructive operations explicit;
+- document retention and expiration parameters;
+- use synthetic data and mocked SDK clients in pull-request tests.
+
+## Approval boundary
+
+This document and the contract tests define the proposed 0.9 public surface.
+Because #140 is an architecture and public-API decision, the pull request remains
+draft until a human reviewer approves naming, ownership, and migration choices.
+Implementation issues #141 and #142 must not broaden the approved surface without
+updating this document and receiving equivalent review.

--- a/src/openai_sdk_helpers/retrieval/__init__.py
+++ b/src/openai_sdk_helpers/retrieval/__init__.py
@@ -1,0 +1,29 @@
+"""Public retrieval contracts for OpenAI files and vector stores."""
+
+from .contracts import (
+    AsyncRetrievalClient,
+    AttributeValue,
+    FileSearchConfig,
+    FileSource,
+    RetrievalOperationResult,
+    RetrievalSearchContent,
+    RetrievalSearchPage,
+    RetrievalSearchResult,
+    SyncRetrievalClient,
+    UploadedFile,
+    VectorStoreReference,
+)
+
+__all__ = [
+    "AsyncRetrievalClient",
+    "AttributeValue",
+    "FileSearchConfig",
+    "FileSource",
+    "RetrievalOperationResult",
+    "RetrievalSearchContent",
+    "RetrievalSearchPage",
+    "RetrievalSearchResult",
+    "SyncRetrievalClient",
+    "UploadedFile",
+    "VectorStoreReference",
+]

--- a/src/openai_sdk_helpers/retrieval/contracts.py
+++ b/src/openai_sdk_helpers/retrieval/contracts.py
@@ -210,7 +210,9 @@ class FileSearchConfig:
     def __post_init__(self) -> None:
         """Normalize store identifiers and copy mutable mappings."""
         identifiers = tuple(
-            dict.fromkeys(_identifier(value, "vector_store_id") for value in self.vector_store_ids)
+            dict.fromkeys(
+                _identifier(value, "vector_store_id") for value in self.vector_store_ids
+            )
         )
         if not identifiers:
             raise ValueError("vector_store_ids must not be empty")

--- a/src/openai_sdk_helpers/retrieval/contracts.py
+++ b/src/openai_sdk_helpers/retrieval/contracts.py
@@ -1,0 +1,411 @@
+"""Public contracts for OpenAI file, vector-store, and search workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO, Generic, Protocol, TypeVar, runtime_checkable
+
+ResourceT = TypeVar("ResourceT")
+FileSource = BinaryIO | Path | str
+AttributeValue = str | bool | int | float
+
+
+def _identifier(value: str, name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must not be empty")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class UploadedFile:
+    """Uploaded OpenAI file with direct access to the SDK resource.
+
+    Parameters
+    ----------
+    id : str
+        OpenAI file identifier.
+    filename : str
+        Server-visible filename.
+    purpose : str
+        Official Files API purpose.
+    bytes : int or None, default=None
+        File size reported by the API.
+    raw : object or None, default=None
+        Underlying official SDK file resource.
+    """
+
+    id: str
+    filename: str
+    purpose: str
+    bytes: int | None = None
+    raw: object | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Normalize identifiers and validate size metadata."""
+        object.__setattr__(self, "id", _identifier(self.id, "id"))
+        object.__setattr__(self, "filename", _identifier(self.filename, "filename"))
+        object.__setattr__(self, "purpose", _identifier(self.purpose, "purpose"))
+        if self.bytes is not None and self.bytes < 0:
+            raise ValueError("bytes must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class VectorStoreReference:
+    """OpenAI vector-store identity and optional SDK resource.
+
+    Parameters
+    ----------
+    id : str
+        Vector-store identifier.
+    name : str or None, default=None
+        Human-readable store name when available.
+    raw : object or None, default=None
+        Underlying official SDK vector-store resource.
+    """
+
+    id: str
+    name: str | None = None
+    raw: object | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Normalize the vector-store identity."""
+        object.__setattr__(self, "id", _identifier(self.id, "id"))
+        if self.name is not None:
+            object.__setattr__(self, "name", _identifier(self.name, "name"))
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalOperationResult(Generic[ResourceT]):
+    """Typed outcome that preserves the original SDK response.
+
+    Parameters
+    ----------
+    operation : str
+        Stable operation name such as ``files.upload``.
+    resource : ResourceT or None
+        Normalized resource produced or affected by the operation.
+    succeeded : bool
+        Whether the operation completed successfully.
+    raw : object or None, default=None
+        Original SDK response or deletion object.
+    error : BaseException or None, default=None
+        Original exception for non-raising batch or cleanup workflows.
+    """
+
+    operation: str
+    resource: ResourceT | None
+    succeeded: bool
+    raw: object | None = field(default=None, repr=False, compare=False)
+    error: BaseException | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Validate operation identity and outcome consistency."""
+        object.__setattr__(self, "operation", _identifier(self.operation, "operation"))
+        if self.succeeded and self.error is not None:
+            raise ValueError("successful operations cannot contain an error")
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalSearchContent:
+    """One text fragment returned from vector-store search."""
+
+    text: str
+    type: str = "text"
+
+    def __post_init__(self) -> None:
+        """Require non-empty content and content type."""
+        object.__setattr__(self, "text", _identifier(self.text, "text"))
+        object.__setattr__(self, "type", _identifier(self.type, "type"))
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalSearchResult:
+    """Normalized vector-store search result with raw SDK access.
+
+    Parameters
+    ----------
+    file_id : str
+        Source file identifier.
+    filename : str
+        Source filename.
+    score : float
+        Relevance score reported by the API.
+    content : tuple[RetrievalSearchContent, ...]
+        Ordered returned content fragments.
+    attributes : Mapping[str, AttributeValue], default={}
+        Source attributes copied from the API result.
+    raw : object or None, default=None
+        Original SDK result item.
+    """
+
+    file_id: str
+    filename: str
+    score: float
+    content: tuple[RetrievalSearchContent, ...]
+    attributes: Mapping[str, AttributeValue] = field(default_factory=dict)
+    raw: object | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Normalize identity, content, and copied attributes."""
+        object.__setattr__(self, "file_id", _identifier(self.file_id, "file_id"))
+        object.__setattr__(self, "filename", _identifier(self.filename, "filename"))
+        if not self.content:
+            raise ValueError("content must not be empty")
+        object.__setattr__(self, "content", tuple(self.content))
+        object.__setattr__(self, "attributes", dict(self.attributes))
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalSearchPage:
+    """Normalized search page with pagination and raw SDK access."""
+
+    query: tuple[str, ...]
+    data: tuple[RetrievalSearchResult, ...]
+    has_more: bool = False
+    next_page: str | None = None
+    raw: object | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Normalize query values, result order, and cursor."""
+        query = tuple(_identifier(value, "query") for value in self.query)
+        if not query:
+            raise ValueError("query must not be empty")
+        object.__setattr__(self, "query", query)
+        object.__setattr__(self, "data", tuple(self.data))
+        if self.next_page is not None:
+            object.__setattr__(
+                self,
+                "next_page",
+                _identifier(self.next_page, "next_page"),
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class FileSearchConfig:
+    """Explicit Responses and Agents File Search tool configuration.
+
+    Parameters
+    ----------
+    vector_store_ids : tuple[str, ...]
+        Existing vector stores to search.
+    max_num_results : int or None, default=None
+        Maximum results requested from File Search.
+    filters : Mapping[str, Any] or None, default=None
+        Official File Search attribute filter object.
+    ranking_options : Mapping[str, Any] or None, default=None
+        Official ranking options passed through unchanged.
+    include_search_results : bool, default=False
+        Whether a Responses request should include raw search results.
+    """
+
+    vector_store_ids: tuple[str, ...]
+    max_num_results: int | None = None
+    filters: Mapping[str, Any] | None = None
+    ranking_options: Mapping[str, Any] | None = None
+    include_search_results: bool = False
+
+    def __post_init__(self) -> None:
+        """Normalize store identifiers and copy mutable mappings."""
+        identifiers = tuple(
+            dict.fromkeys(_identifier(value, "vector_store_id") for value in self.vector_store_ids)
+        )
+        if not identifiers:
+            raise ValueError("vector_store_ids must not be empty")
+        if self.max_num_results is not None and self.max_num_results < 1:
+            raise ValueError("max_num_results must be positive")
+        object.__setattr__(self, "vector_store_ids", identifiers)
+        if self.filters is not None:
+            object.__setattr__(self, "filters", dict(self.filters))
+        if self.ranking_options is not None:
+            object.__setattr__(self, "ranking_options", dict(self.ranking_options))
+
+    def as_tool(self) -> dict[str, Any]:
+        """Return official SDK-shaped File Search tool configuration."""
+        tool: dict[str, Any] = {
+            "type": "file_search",
+            "vector_store_ids": list(self.vector_store_ids),
+        }
+        if self.max_num_results is not None:
+            tool["max_num_results"] = self.max_num_results
+        if self.filters is not None:
+            tool["filters"] = dict(self.filters)
+        if self.ranking_options is not None:
+            tool["ranking_options"] = dict(self.ranking_options)
+        return tool
+
+    def response_includes(self) -> tuple[str, ...]:
+        """Return optional Responses include values for raw search results."""
+        if self.include_search_results:
+            return ("file_search_call.results",)
+        return ()
+
+
+@runtime_checkable
+class SyncRetrievalClient(Protocol):
+    """Dependency-injected synchronous retrieval lifecycle contract."""
+
+    @property
+    def sdk_client(self) -> object:
+        """Return the underlying official OpenAI client."""
+        ...
+
+    def upload_file(
+        self,
+        source: FileSource,
+        *,
+        purpose: str,
+        expires_after: Mapping[str, Any] | None = None,
+    ) -> RetrievalOperationResult[UploadedFile]:
+        """Upload one file without implying vector-store attachment."""
+        ...
+
+    def create_vector_store(
+        self,
+        *,
+        name: str,
+        file_ids: Sequence[str] = (),
+        attributes: Mapping[str, AttributeValue] | None = None,
+        expires_after: Mapping[str, Any] | None = None,
+        chunking_strategy: Mapping[str, Any] | None = None,
+    ) -> RetrievalOperationResult[VectorStoreReference]:
+        """Create one vector store and preserve the SDK resource."""
+        ...
+
+    def attach_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+        *,
+        attributes: Mapping[str, AttributeValue] | None = None,
+        chunking_strategy: Mapping[str, Any] | None = None,
+    ) -> RetrievalOperationResult[UploadedFile]:
+        """Attach an existing file to an existing vector store."""
+        ...
+
+    def detach_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> RetrievalOperationResult[UploadedFile]:
+        """Remove a file from a store without deleting the Files resource."""
+        ...
+
+    def search(
+        self,
+        vector_store_id: str,
+        query: str | Sequence[str],
+        *,
+        filters: Mapping[str, Any] | None = None,
+        max_num_results: int | None = None,
+        ranking_options: Mapping[str, Any] | None = None,
+        rewrite_query: bool | None = None,
+    ) -> RetrievalSearchPage:
+        """Search one vector store and return normalized results."""
+        ...
+
+    def delete_file(self, file_id: str) -> RetrievalOperationResult[UploadedFile]:
+        """Delete the underlying Files resource explicitly."""
+        ...
+
+    def delete_vector_store(
+        self,
+        vector_store_id: str,
+    ) -> RetrievalOperationResult[VectorStoreReference]:
+        """Delete a vector store explicitly."""
+        ...
+
+
+@runtime_checkable
+class AsyncRetrievalClient(Protocol):
+    """Dependency-injected asynchronous retrieval lifecycle contract."""
+
+    @property
+    def sdk_client(self) -> object:
+        """Return the underlying official asynchronous OpenAI client."""
+        ...
+
+    def upload_file(
+        self,
+        source: FileSource,
+        *,
+        purpose: str,
+        expires_after: Mapping[str, Any] | None = None,
+    ) -> Awaitable[RetrievalOperationResult[UploadedFile]]:
+        """Upload one file without implying vector-store attachment."""
+        ...
+
+    def create_vector_store(
+        self,
+        *,
+        name: str,
+        file_ids: Sequence[str] = (),
+        attributes: Mapping[str, AttributeValue] | None = None,
+        expires_after: Mapping[str, Any] | None = None,
+        chunking_strategy: Mapping[str, Any] | None = None,
+    ) -> Awaitable[RetrievalOperationResult[VectorStoreReference]]:
+        """Create one vector store and preserve the SDK resource."""
+        ...
+
+    def attach_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+        *,
+        attributes: Mapping[str, AttributeValue] | None = None,
+        chunking_strategy: Mapping[str, Any] | None = None,
+    ) -> Awaitable[RetrievalOperationResult[UploadedFile]]:
+        """Attach an existing file to an existing vector store."""
+        ...
+
+    def detach_file(
+        self,
+        vector_store_id: str,
+        file_id: str,
+    ) -> Awaitable[RetrievalOperationResult[UploadedFile]]:
+        """Remove a file from a store without deleting the Files resource."""
+        ...
+
+    def search(
+        self,
+        vector_store_id: str,
+        query: str | Sequence[str],
+        *,
+        filters: Mapping[str, Any] | None = None,
+        max_num_results: int | None = None,
+        ranking_options: Mapping[str, Any] | None = None,
+        rewrite_query: bool | None = None,
+    ) -> Awaitable[RetrievalSearchPage]:
+        """Search one vector store and return normalized results."""
+        ...
+
+    def delete_file(
+        self,
+        file_id: str,
+    ) -> Awaitable[RetrievalOperationResult[UploadedFile]]:
+        """Delete the underlying Files resource explicitly."""
+        ...
+
+    def delete_vector_store(
+        self,
+        vector_store_id: str,
+    ) -> Awaitable[RetrievalOperationResult[VectorStoreReference]]:
+        """Delete a vector store explicitly."""
+        ...
+
+
+__all__ = [
+    "AsyncRetrievalClient",
+    "AttributeValue",
+    "FileSearchConfig",
+    "FileSource",
+    "RetrievalOperationResult",
+    "RetrievalSearchContent",
+    "RetrievalSearchPage",
+    "RetrievalSearchResult",
+    "SyncRetrievalClient",
+    "UploadedFile",
+    "VectorStoreReference",
+]

--- a/tests/test_retrieval_contract.py
+++ b/tests/test_retrieval_contract.py
@@ -47,12 +47,15 @@ def test_resource_types_preserve_raw_sdk_objects() -> None:
 
     assert uploaded.raw is raw_file
     assert store.raw is raw_store
-    assert RetrievalOperationResult(
-        operation="files.upload",
-        resource=uploaded,
-        succeeded=True,
-        raw=raw_file,
-    ).raw is raw_file
+    assert (
+        RetrievalOperationResult(
+            operation="files.upload",
+            resource=uploaded,
+            succeeded=True,
+            raw=raw_file,
+        ).raw
+        is raw_file
+    )
 
 
 def test_file_search_config_is_explicit_and_deduplicated() -> None:

--- a/tests/test_retrieval_contract.py
+++ b/tests/test_retrieval_contract.py
@@ -1,0 +1,100 @@
+"""Contract tests for the approved retrieval target surface."""
+
+from __future__ import annotations
+
+from openai_sdk_helpers import retrieval
+from openai_sdk_helpers.retrieval import (
+    FileSearchConfig,
+    RetrievalOperationResult,
+    RetrievalSearchContent,
+    RetrievalSearchPage,
+    RetrievalSearchResult,
+    UploadedFile,
+    VectorStoreReference,
+)
+
+EXPECTED_RETRIEVAL_API = (
+    "AsyncRetrievalClient",
+    "AttributeValue",
+    "FileSearchConfig",
+    "FileSource",
+    "RetrievalOperationResult",
+    "RetrievalSearchContent",
+    "RetrievalSearchPage",
+    "RetrievalSearchResult",
+    "SyncRetrievalClient",
+    "UploadedFile",
+    "VectorStoreReference",
+)
+
+
+def test_retrieval_module_exports_are_explicit() -> None:
+    assert tuple(retrieval.__all__) == EXPECTED_RETRIEVAL_API
+    assert all(hasattr(retrieval, name) for name in EXPECTED_RETRIEVAL_API)
+
+
+def test_resource_types_preserve_raw_sdk_objects() -> None:
+    raw_file = object()
+    raw_store = object()
+    uploaded = UploadedFile(
+        id="file_123",
+        filename="guide.pdf",
+        purpose="user_data",
+        bytes=42,
+        raw=raw_file,
+    )
+    store = VectorStoreReference(id="vs_123", name="guides", raw=raw_store)
+
+    assert uploaded.raw is raw_file
+    assert store.raw is raw_store
+    assert RetrievalOperationResult(
+        operation="files.upload",
+        resource=uploaded,
+        succeeded=True,
+        raw=raw_file,
+    ).raw is raw_file
+
+
+def test_file_search_config_is_explicit_and_deduplicated() -> None:
+    config = FileSearchConfig(
+        vector_store_ids=("vs_1", "vs_1", "vs_2"),
+        max_num_results=5,
+        filters={"type": "eq", "key": "region", "value": "eu"},
+        ranking_options={"score_threshold": 0.4},
+        include_search_results=True,
+    )
+
+    assert config.vector_store_ids == ("vs_1", "vs_2")
+    assert config.as_tool() == {
+        "type": "file_search",
+        "vector_store_ids": ["vs_1", "vs_2"],
+        "max_num_results": 5,
+        "filters": {"type": "eq", "key": "region", "value": "eu"},
+        "ranking_options": {"score_threshold": 0.4},
+    }
+    assert config.response_includes() == ("file_search_call.results",)
+
+
+def test_search_results_are_normalized_without_losing_raw_access() -> None:
+    raw_item = object()
+    raw_page = object()
+    item = RetrievalSearchResult(
+        file_id="file_123",
+        filename="guide.pdf",
+        score=0.91,
+        content=(RetrievalSearchContent("Relevant paragraph"),),
+        attributes={"region": "eu", "year": 2026},
+        raw=raw_item,
+    )
+    page = RetrievalSearchPage(
+        query=("first question", "second question"),
+        data=(item,),
+        has_more=True,
+        next_page="cursor_123",
+        raw=raw_page,
+    )
+
+    assert page.data[0].raw is raw_item
+    assert page.raw is raw_page
+    assert page.query == ("first question", "second question")
+    assert page.data[0].content[0].text == "Relevant paragraph"


### PR DESCRIPTION
## Stacked roadmap pull request

This pull request implements #140 on top of PR #156, PR #154, and the 0.8.0 release candidate in PR #153. It is ready for human architecture review but must not merge until prerequisite releases are complete.

## What changed

- define one focused `openai_sdk_helpers.retrieval` target namespace
- add typed resource, operation-result, search-result, pagination, and File Search configuration contracts
- add matching sync and async dependency-injection protocols
- preserve raw official SDK resources and clients as explicit escape hatches
- separate Files lifecycle, vector-store lifecycle/direct search, File Search configuration, and message composition
- document explicit ownership, detach-versus-delete semantics, cleanup, filters, ranking, query rewriting, chunking, expiration, and diagnostics
- inventory every existing retrieval-related surface
- classify each legacy surface as keep, adapt, internalize, deprecate, or split
- define a staged compatibility and deprecation plan with no immediate removals
- add contract tests without implementing network operations prematurely

## Scope boundary

Issue #140 approves architecture and migration contracts only. Network implementation belongs to #141 and File Search request/result adapters belong to #142. Existing imports remain supported.

## Validation completed on final head `0f8ebdf`

- docstrings, Black, Pyright, and Markdown links: passed
- Python 3.10–3.13 tests and coverage: passed
- minimum/latest OpenAI SDK compatibility and distribution builds: passed in all final and synchronization runs
- clean `core`, `extract`, `ui`, and `all` installs: passed
- installed-wheel package-data, CLI, and supported-example smoke tests: passed
- AI-native governance, Security, and CodeQL: passed

Implements #140. Ready for naming, ownership, and migration review; merge only after prerequisite PRs.