### PR TITLE
Sync retrieval contract formatting into lifecycle stack

### DIFF
--- a/src/openai_sdk_helpers/retrieval/contracts.py
+++ b/src/openai_sdk_helpers/retrieval/contracts.py
@@ -210,7 +210,9 @@ class FileSearchConfig:
     def __post_init__(self) -> None:
         """Normalize store identifiers and copy mutable mappings."""
         identifiers = tuple(
-            dict.fromkeys(_identifier(value, "vector_store_id") for value in self.vector_store_ids)
+            dict.fromkeys(
+                _identifier(value, "vector_store_id") for value in self.vector_store_ids
+            )
         )
         if not identifiers:
             raise ValueError("vector_store_ids must not be empty")

--- a/tests/test_retrieval_contract.py
+++ b/tests/test_retrieval_contract.py
@@ -47,12 +47,15 @@ def test_resource_types_preserve_raw_sdk_objects() -> None:
 
     assert uploaded.raw is raw_file
     assert store.raw is raw_store
-    assert RetrievalOperationResult(
-        operation="files.upload",
-        resource=uploaded,
-        succeeded=True,
-        raw=raw_file,
-    ).raw is raw_file
+    assert (
+        RetrievalOperationResult(
+            operation="files.upload",
+            resource=uploaded,
+            succeeded=True,
+            raw=raw_file,
+        ).raw
+        is raw_file
+    )
 
 
 def test_file_search_config_is_explicit_and_deduplicated() -> None:


### PR DESCRIPTION
Internal stacked-branch synchronization only.

This merges the final #140 formatter corrections from `agent/retrieval-contract` into `agent/retrieval-lifecycle` without changing `main` or closing any roadmap issue.